### PR TITLE
Hide Angular templating code until Angular can display them properly

### DIFF
--- a/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
+++ b/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
@@ -797,3 +797,12 @@ body.paperwork-guest {
 .btn-info    { .paperwork-btn-styles(@btn-info-bg, darken(@btn-info-bg, 12%)); }
 .btn-warning { .paperwork-btn-styles(@btn-warning-bg, darken(@btn-warning-bg, 12%)); }
 .btn-danger  { .paperwork-btn-styles(@btn-danger-bg, darken(@btn-danger-bg, 12%)); }
+
+/*
+ * Hide Angular templating code
+ * Usually template text is displayed
+ * until Angular is invoked
+ */
+[ng-cloak] {
+  display: none !important;
+}

--- a/frontend/app/views/main.blade.php
+++ b/frontend/app/views/main.blade.php
@@ -14,7 +14,7 @@
 						<li>
 							<span class="tree-header tree-header-shortcuts"><i class="fa fa-chevron-down"></i> [[Lang::get('keywords.shortcuts')]]</span>
 							<ul class="tree-child">
-								<li class="tree-notebook" ng-repeat="shortcut in shortcuts | orderBy:'sortkey'">
+								<li class="tree-notebook" ng-repeat="shortcut in shortcuts | orderBy:'sortkey'" ng-cloak>
 									<span ng-click="openNotebook(shortcut.id, shortcut.type, notebook.id)" ng-class="{ 'active': notebook.id == getNotebookSelectedId() }"><i class="fa fa-book"></i> {{shortcut.title}}</span>
 								</li>
 							</ul>
@@ -22,7 +22,7 @@
 						<li>
 							<span class="tree-header tree-header-notebooks"><i class="fa fa-chevron-down"></i> [[Lang::get('keywords.notebooks')]]</span>
 							<ul class="tree-child">
-								<li class="tree-notebook" ng-repeat="notebook in notebooks | orderBy:'title'">
+								<li class="tree-notebook" ng-repeat="notebook in notebooks | orderBy:'title'" ng-cloak>
 									<span ng-click="openNotebook(notebook.id, notebook.type, notebook.id)" ng-class="{ 'active': notebook.id == getNotebookSelectedId() }"><i class="fa {{ notebookIconByType(notebook.type) }}"></i> {{notebook.title}}</span>
 									<ul class="tree-child">
 										<li class="tree-notebook" ng-repeat="child in notebook.children | orderBy:'title'">
@@ -35,7 +35,7 @@
 						<li>
 							<span class="tree-header tree-header-tags"><i class="fa fa-chevron-down"></i> [[Lang::get('keywords.tags')]]</span>
 							<ul class="tree-child">
-								<li class="tree-tag" ng-repeat="tag in tags | orderBy:'title':reverse">
+								<li class="tree-tag" ng-repeat="tag in tags | orderBy:'title':reverse" ng-cloak>
 									<span ng-click="openTag(tag.id)" ng-class="{ 'active': tag.id == tagsSelectedId }"><i class="fa fa-tag"></i> {{tag.title}}</span>
 								</li>
 							</ul>
@@ -47,7 +47,7 @@
 
 		<div id="sidebarNotes" class="col-sm-4 col-sm-offset-3 col-md-3 col-md-offset-2 sidebar hidden-xs animate-panel" ng-controller="paperworkSidebarNotesController" ng-show="isVisible()">
 			<ul id="notes-list" class="nav nav-sidebar notes-list sidebar-no-border" ng-controller="paperworkNotesListController">
-				<li class="notes-list-item" ng-repeat="note in notes" ng-click="noteSelect(note.notebook_id, note.id)" ng-dblclick="editNote(note.notebook_id, note.id)" ng-class="{ 'active': (note.notebook_id + '-' + note.id == getNoteSelectedId() || (editMultipleNotes && notesSelectedIds[note.id])) }">
+				<li class="notes-list-item" ng-cloak ng-repeat="note in notes" ng-click="noteSelect(note.notebook_id, note.id)" ng-dblclick="editNote(note.notebook_id, note.id)" ng-class="{ 'active': (note.notebook_id + '-' + note.id == getNoteSelectedId() || (editMultipleNotes && notesSelectedIds[note.id])) }">
 					<div class="notes-list-item-checkbox col-sm-1" ng-show="editMultipleNotes">
 						<input name="notes[]" type="checkbox" value="{{ note.id }}" ng-model="notesSelectedIds[note.id]" ng-click="$event.stopPropagation();" ng-dblclick="$event.stopPropagation();">
 					</div>


### PR DESCRIPTION
This fixes #51. This issue arises because the CSS for ng-cloak'ed elements apparently isn't loaded until Angular starts, hence the delayed flicker when you merely ng-cloak elements. The simple fix is to just add the CSS to our less files so cloaked elements never show at all.