### PR TITLE
cloak 'file','edit' dropdowns and search

### DIFF
--- a/frontend/app/views/partials/menu-main.blade.php
+++ b/frontend/app/views/partials/menu-main.blade.php
@@ -1,4 +1,4 @@
-<ul class="nav navbar-nav animate-panel" ng-show="navbarMainMenu">
+<ul class="nav navbar-nav animate-panel" ng-cloak ng-show="navbarMainMenu">
 	<li class="dropdown">
 		<a href="" class="dropdown-toggle transition-effect" data-toggle="dropdown">[[Lang::get('keywords.file')]] <span class="caret"></span></a>
 		<ul class="dropdown-menu" role="menu">

--- a/frontend/app/views/partials/search-main.blade.php
+++ b/frontend/app/views/partials/search-main.blade.php
@@ -1,4 +1,4 @@
-<form ng-controller="paperworkSidebarNotesController" ng-show="navbarSearchForm" class="navbar-form navbar-left animate-panel" id="searchForm" role="form" ng-submit="submitSearch()">
+<form ng-controller="paperworkSidebarNotesController" ng-cloak ng-show="navbarSearchForm" class="navbar-form navbar-left animate-panel" id="searchForm" role="form" ng-submit="submitSearch()">
 	<div class="form-group">
 		<input type="text" class="form-control navbar-search" placeholder="[[Lang::get('keywords.search_dotdotdot')]]" ng-model="search">
 	</div>


### PR DESCRIPTION
This fixes an issue where the 'File' and 'Edit' dropdowns, as well as the searchbar, flicker before angular loads.

In the case of the main menu, they flicker and then show, in other screens they flicker and then hide. But now they don't show at all initially.

@devilx @Liongold