### PR TITLE
fix csrf filter vulnerability

### DIFF
--- a/frontend/app/filters.php
+++ b/frontend/app/filters.php
@@ -116,7 +116,7 @@ Route::filter('guest', function()
 
 Route::filter('csrf', function()
 {
-	if (Session::token() != Input::get('_token'))
+	if (Session::token() !== Input::get('_token'))
 	{
 		throw new Illuminate\Session\TokenMismatchException;
 	}


### PR DESCRIPTION
It seems that paperwork has not used the csrf filter at the moment. But according to this article (http://blog.laravel.com/csrf-vulnerability-in-laravel-4/), I believe it is better to apply the recommended fix.