### PR TITLE
Issue 51 - Add Gulp to build recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
   - cd ..
   - mkdir -p build/logs
   - (cd "$(pwd)/frontend/"; phpunit)
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,9 @@ before_script:
   - composer install --dev --no-interaction -d "$(pwd)/frontend/"
 
 script:
+  - cd frontend
+  - npm install 
+  - gulp
+  - cd ..
   - mkdir -p build/logs
   - (cd "$(pwd)/frontend/"; phpunit)


### PR DESCRIPTION
By going into ./frontend and running
    npm install
    gulp
we compile all our Less into fresh CSS every build (and anything else gulp is doing).