### PR TITLE
Added password reminder email subject

### DIFF
--- a/frontend/app/controllers/UserController.php
+++ b/frontend/app/controllers/UserController.php
@@ -169,7 +169,7 @@ class UserController extends BaseController {
 	protected function getPasswordRemindResponse() {
 		return Password::remind(Input::only("username"), function($message)
 			{
-				$message->subject('Reset your Paperwork Password');
+				$message->subject(Lang::get('keywords.password_reset_request'));
 			});
 	}
 

--- a/frontend/app/controllers/UserController.php
+++ b/frontend/app/controllers/UserController.php
@@ -167,7 +167,10 @@ class UserController extends BaseController {
 	}
 	// TODO: Password reminders not working out of the box, since we don't have an "email" column.
 	protected function getPasswordRemindResponse() {
-		return Password::remind(Input::only("username"));
+		return Password::remind(Input::only("username"), function($message)
+			{
+				$message->subject('Reset your Paperwork Password');
+			});
 	}
 
 	protected function isInvalidUser($response) {

--- a/frontend/app/lang/en/keywords.php
+++ b/frontend/app/lang/en/keywords.php
@@ -52,6 +52,7 @@ return array(
 	'close_without_saving_message' => 'There are unsaved changes in your note. Do you really want to close this note and dismiss all unsaved changes?',
 	'search_dotdotdot' => 'Search...',
 	'reset_password' => 'Reset password',
+	'password_reset_request' => 'Reset your Paperwork Password',
 	'toggle_navigation' => 'Toggle navigation',
 	'cancel' => 'Cancel',
 	'create' => 'Create',


### PR DESCRIPTION
when password reset emails are enabled (by editing the Laravel RemindableTrait.php file as per https://github.com/twostairs/paperwork/issues/69) they are sent without a subject by default.
This change adds a subject to the email:

![paperwork](https://cloud.githubusercontent.com/assets/10751405/5954922/b8b236a2-a7f1-11e4-9d18-775f0a7e4b8d.png)
