### PR TITLE
Make remember_token nullable

### DIFF
--- a/frontend/app/database/migrations/2014_07_22_194050_initialize.php
+++ b/frontend/app/database/migrations/2014_07_22_194050_initialize.php
@@ -18,7 +18,7 @@ class Initialize extends Migration {
             $table->string('password');
             $table->string('firstname');
             $table->string('lastname');
-            $table->string('remember_token');
+            $table->string('remember_token', 100)->nullable();
             $table->timestamps();
             $table->softDeletes();
             $table->engine = 'InnoDB';


### PR DESCRIPTION
According to http://laravel.com/docs/4.2/upgrade#upgrade-4.1.26

```remember_token``` should be nullable (I guess size 100 is optional).

This may solve https://github.com/twostairs/paperwork/issues/116 as well