### PR TITLE
Remove links in note after deleting attachment.

### DIFF
--- a/frontend/app/js/paperwork/paperworkFileUploadController.js
+++ b/frontend/app/js/paperwork/paperworkFileUploadController.js
@@ -76,12 +76,15 @@ paperworkModule.controller('paperworkFileUploadController', ['$scope', '$rootSco
       });
     } else {
       paperworkNotesService.deleteNoteVersionAttachment(notebookId, noteId, versionId, attachmentId, function(response) {
+        var fileUrl = '/api/v1/notebooks/' + notebookId + '/notes/' + noteId + '/versions/' + versionId + '/attachments/' + attachmentId + '/raw';
         var i, l = $rootScope.fileList.length;
         for(i=0; i<l; i++) {
           if(typeof $rootScope.fileList[i] != "undefined" && typeof $rootScope.fileList[i].id != "undefined" && $rootScope.fileList[i].id == attachmentId) {
             $rootScope.fileList.splice(i, 1);
           }
         }
+        
+        $rootScope.$broadcast('deleteAttachmentLink', { 'url': fileUrl });
       });
     }
     return true;

--- a/frontend/app/js/paperwork/paperworkNotesEditController.js
+++ b/frontend/app/js/paperwork/paperworkNotesEditController.js
@@ -102,6 +102,24 @@ paperworkModule.controller('paperworkNotesEditController', function($scope, $roo
   //   $(this).trigger(e);
   // });
 
+
+  $scope.$on('deleteAttachmentLink', function(ev, args) {
+    if(typeof args == "undefined" || typeof args.url == "undefined") {
+      return false;
+    }
+
+    var documentNode = CKEDITOR.instances['content'].document.$,
+        elementCollection = documentNode.getElementsByTagName('a');
+
+    var i = elementCollection.length;
+    while(i--) {
+      var element = elementCollection[i];
+      if(element.getAttribute("href") == args.url) {
+        element.parentNode.removeChild(element);	
+      }
+    }
+  });
+
   $scope.$on('insertAttachmentLink', function(ev, args) {
     if(typeof args == "undefined" || typeof args.url == "undefined" || typeof args.mimetype == "undefined") {
       return false;

--- a/frontend/app/views/templates/paperworkNoteShow.blade.php
+++ b/frontend/app/views/templates/paperworkNoteShow.blade.php
@@ -23,6 +23,7 @@
 		      			</div>
 		      		'><i class="fa fa-info-circle"></i></button>
 		      		<button class="btn btn-default navbar-btn" data-toggle="freqselector" data-target="#wayback-machine"><i class="fa fa-history"></i></button>
+				<button class="btn btn-default navbar-btn" ng-controller="paperworkSidebarNotesController" ng-click="editNote(note.notebook_id, note.id)"><i class="fa fa-pencil"></i></button>
 		      		<button class="btn btn-default navbar-btn"><i class="fa fa-share-alt"></i></button>
 	      		</div>
 	      	</li>


### PR DESCRIPTION
Fixes #141

- Code add to remove hyperlinks to an attachment when an attachment is being deleted.
- Edit icon add to note template.

Will use different branches in the future since two unrelated commits are now in the same push request.
Let me know if you want DOM manipulation done by jQuery.