### PR TITLE
Fixes being able to create a new note when using strict sql database

### DIFF
--- a/frontend/app/controllers/api/v1/ApiNotesController.php
+++ b/frontend/app/controllers/api/v1/ApiNotesController.php
@@ -193,7 +193,7 @@ class ApiNotesController extends BaseController {
 
 		$note = new Note();
 
-		$version = new Version(array('title' => $newNote->get("title"), 'content' => $newNote->get("content")));
+		$version = new Version(array('title' => $newNote->get("title"), 'content' => $newNote->get("content"), 'content_preview' => $newNote->get("content_preview")));
 		$version->save();
 		$note->version()->associate($version);
 
@@ -206,7 +206,7 @@ class ApiNotesController extends BaseController {
 			->where('notebooks.id', '=', $notebookId)
 			->whereNull('notebooks.deleted_at')
 			->first();
-
+        
 		if(is_null($notebook)){
 			return PaperworkHelpers::apiResponse(PaperworkHelpers::STATUS_NOTFOUND, array());
 		}
@@ -215,7 +215,8 @@ class ApiNotesController extends BaseController {
 
 		$note->save();
 
-		$note->users()->attach(Auth::user()->id);
+        // TODO: Should we inherit the umask from the notebook?
+		$note->users()->attach(Auth::user()->id, array('umask' => PaperworkHelpers::UMASK_OWNER));
 
 		$tagIds = ApiTagsController::createOrGetTags($newNote->get('tags'));
 

--- a/frontend/app/js/paperwork/paperworkSidebarNotesController.js
+++ b/frontend/app/js/paperwork/paperworkSidebarNotesController.js
@@ -35,7 +35,8 @@ paperworkModule.controller('paperworkSidebarNotesController', function($scope, $
 
     var data = {
       'title': $rootScope.i18n.keywords.untitled || 'Untitled',
-      'content': ''
+      'content': '',
+      'content_preview': ''
     };
 
     var callback = (function(_notebookId) {


### PR DESCRIPTION
Fixes #159 
Sets 2 non-nullable fields in the database when creating a new note.
It was either this way, or make changes to the database to allow either/both fields to be nullable or have default values.