### PR TITLE
Minify JS files with gulp-uglify

### DIFF
--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -4,6 +4,7 @@ var concat = require('gulp-concat');
 var rename = require('gulp-rename');
 var livereload = require('gulp-livereload');
 var uglify = require('gulp-uglify');
+var sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('compileLessBootstrapTheme', function() {
 	gulp
@@ -115,8 +116,10 @@ gulp.task('compileJsPaperwork', function() {
 			'app/js/paperwork/paperworkWaybackController.js',
 			'app/js/paperwork/paperworkFourOhFourController.js'
 		])
+		.pipe(sourcemaps.init())
 		.pipe(concat('paperwork.min.js'))
 		.pipe(uglify())
+		.pipe(sourcemaps.write())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -3,6 +3,7 @@ var less = require('gulp-less');
 var concat = require('gulp-concat');
 var rename = require('gulp-rename');
 var livereload = require('gulp-livereload');
+var uglify = require('gulp-uglify');
 
 gulp.task('compileLessBootstrapTheme', function() {
 	gulp
@@ -82,6 +83,7 @@ gulp.task('compileJsBootstrap', function() {
 			'app/js/bootstrap-tree.js'
 		])
 		.pipe(concat('bootstrap.min.js'))
+		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -114,6 +116,7 @@ gulp.task('compileJsPaperwork', function() {
 			'app/js/paperwork/paperworkFourOhFourController.js'
 		])
 		.pipe(concat('paperwork.min.js'))
+		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -130,6 +133,7 @@ gulp.task('compileJsAngular', function() {
 			'app/js/angular-utf8-base64.js'
 		])
 		.pipe(concat('angular.min.js'))
+		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -142,6 +146,7 @@ gulp.task('compileJsJquery', function() {
 			'app/js/jquery.scrollTo.js'
 		])
 		.pipe(concat('jquery.min.js'))
+		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -154,6 +159,7 @@ gulp.task('compileJsTagsinput', function() {
 			'app/js/typeahead.js'
 		])
 		.pipe(concat('tagsinput.min.js'))
+		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -165,6 +171,7 @@ gulp.task('compileJsLibraries', function() {
 			'app/js/retina.js'
 		])
 		.pipe(concat('libraries.min.js'))
+		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -176,6 +183,7 @@ gulp.task('compileJsLtIe9Compat', function() {
 			'app/js/respond.js'
 		])
 		.pipe(concat('ltie9compat.min.js'))
+		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -186,6 +194,7 @@ gulp.task('compileJsLtIe11Compat', function() {
 			'app/js/ie10-viewport-bug-workaround.js'
 		])
 		.pipe(concat('ltie11compat.min.js'))
+		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -4,7 +4,6 @@ var concat = require('gulp-concat');
 var rename = require('gulp-rename');
 var livereload = require('gulp-livereload');
 var uglify = require('gulp-uglify');
-var sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('compileLessBootstrapTheme', function() {
 	gulp
@@ -84,7 +83,6 @@ gulp.task('compileJsBootstrap', function() {
 			'app/js/bootstrap-tree.js'
 		])
 		.pipe(concat('bootstrap.min.js'))
-		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -116,10 +114,7 @@ gulp.task('compileJsPaperwork', function() {
 			'app/js/paperwork/paperworkWaybackController.js',
 			'app/js/paperwork/paperworkFourOhFourController.js'
 		])
-		.pipe(sourcemaps.init())
 		.pipe(concat('paperwork.min.js'))
-		.pipe(uglify())
-		.pipe(sourcemaps.write())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -136,7 +131,6 @@ gulp.task('compileJsAngular', function() {
 			'app/js/angular-utf8-base64.js'
 		])
 		.pipe(concat('angular.min.js'))
-		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -149,7 +143,6 @@ gulp.task('compileJsJquery', function() {
 			'app/js/jquery.scrollTo.js'
 		])
 		.pipe(concat('jquery.min.js'))
-		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -162,7 +155,6 @@ gulp.task('compileJsTagsinput', function() {
 			'app/js/typeahead.js'
 		])
 		.pipe(concat('tagsinput.min.js'))
-		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -174,7 +166,6 @@ gulp.task('compileJsLibraries', function() {
 			'app/js/retina.js'
 		])
 		.pipe(concat('libraries.min.js'))
-		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -186,7 +177,6 @@ gulp.task('compileJsLtIe9Compat', function() {
 			'app/js/respond.js'
 		])
 		.pipe(concat('ltie9compat.min.js'))
-		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
 });
@@ -197,15 +187,22 @@ gulp.task('compileJsLtIe11Compat', function() {
 			'app/js/ie10-viewport-bug-workaround.js'
 		])
 		.pipe(concat('ltie11compat.min.js'))
-		.pipe(uglify())
 		.pipe(gulp.dest('public/js'))
 		.pipe(livereload());
+});
+
+gulp.task('minifyJs', function() {
+	gulp
+		.src('public/js/*.js')
+		.pipe(uglify())
+		.pipe(gulp.dest('public/js'));
 });
 
 gulp.task('less', ['compileLessBootstrapTheme', 'compileLessPaperworkThemeV1', 'compileLessFontLato', 'compileLessFreqselector', 'compileLessTypeahead']);
 gulp.task('js', ['compileJsBootstrap', 'compileJsPaperwork', 'compileJsAngular', 'compileJsJquery', 'compileJsTagsinput', 'compileJsLibraries', 'compileJsLtIe9Compat', 'compileJsLtIe11Compat']);
 
 gulp.task('default', ['less', 'js']);
+gulp.task('prod', ['default', 'minifyJs']);
 
 gulp.task('watch', function() {
   livereload.listen();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,6 @@
     "gulp-less": "^2.0.1",
     "gulp-livereload": "^3.2.0",
     "gulp-rename": "^1.2.0",
-    "gulp-uglify": "~1.1.0",
-    "gulp-sourcemaps": "~1.3.0"
+    "gulp-uglify": "~1.1.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
     "gulp-concat": "^2.4.2",
     "gulp-less": "^2.0.1",
     "gulp-livereload": "^3.2.0",
-    "gulp-rename": "^1.2.0"
+    "gulp-rename": "^1.2.0",
+    "gulp-uglify": "~1.1.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
     "gulp-less": "^2.0.1",
     "gulp-livereload": "^3.2.0",
     "gulp-rename": "^1.2.0",
-    "gulp-uglify": "~1.1.0"
+    "gulp-uglify": "~1.1.0",
+    "gulp-sourcemaps": "~1.3.0"
   }
 }


### PR DESCRIPTION
I don't know if you had any special reason for not minifying the JavaScript. Anyway, it's a small change and here it is if you want it. I added sourcemaps for the Paperwork files so you can still debug in the browser.