### PR TITLE
Remove dependency annotation

### DIFF
--- a/frontend/app/js/paperwork/constructor/constructor.controller.js
+++ b/frontend/app/js/paperwork/constructor/constructor.controller.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').controller('ConstructorController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NetService',
-   function($scope, $rootScope, $location, $routeParams, paperworkNetService) {
+angular.module('paperworkNotes').controller('ConstructorController', function($scope, $rootScope, $location, $routeParams, paperworkNetService) {
      if($rootScope.initDone) {
        return;
      }
@@ -104,4 +102,4 @@ angular.module('paperworkNotes').controller('ConstructorController',
      $rootScope.modalNotebookSelect = function(modalData) {
        $rootScope.modalGeneric('modalNotebookSelect', modalData);
      };
-   }]);
+   });

--- a/frontend/app/js/paperwork/default/default.controller.js
+++ b/frontend/app/js/paperwork/default/default.controller.js
@@ -1,4 +1,2 @@
-angular.module('paperworkNotes').controller('DefaultController',
-  ['$scope', '$location', '$routeParams', 'NotesService',
-   function($scope, $location, $routeParams, notesService) {
-   }]);
+angular.module('paperworkNotes').controller('DefaultController', function($scope, $location, $routeParams, notesService) {
+});

--- a/frontend/app/js/paperwork/file_upload/file_upload.controller.js
+++ b/frontend/app/js/paperwork/file_upload/file_upload.controller.js
@@ -1,6 +1,5 @@
 angular.module('paperworkNotes').controller('FileUploadController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'FileUploader', 'NotesService',
-   function($scope, $rootScope, $location, $routeParams, FileUploader, paperworkNotesService) {
+    function($scope, $rootScope, $location, $routeParams, FileUploader, paperworkNotesService) {
      var uploader = $scope.uploader = new FileUploader({
        url: $rootScope.uploadUrl
      });
@@ -129,4 +128,4 @@ angular.module('paperworkNotes').controller('FileUploadController',
            break;
        }
      };
-   }]);
+   });

--- a/frontend/app/js/paperwork/four_oh_four/four_oh_four.controller.js
+++ b/frontend/app/js/paperwork/four_oh_four/four_oh_four.controller.js
@@ -1,7 +1,5 @@
-angular.module('paperworkNotes').controller('FourOhFourController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NotesService',
-    function($scope, $rootScope, $location, $routeParams, notesService) {
+angular.module('paperworkNotes').controller('FourOhFourController', function($scope, $rootScope, $location, $routeParams, notesService) {
       $rootScope.navbarMainMenu = true;
       $rootScope.navbarSearchForm = true;
       $rootScope.expandedNoteLayout = false;
-    }]);
+    });

--- a/frontend/app/js/paperwork/messagebox/messagebox.controller.js
+++ b/frontend/app/js/paperwork/messagebox/messagebox.controller.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').controller('MessageBoxController',
-  ['$scope', '$rootScope', '$location', '$routeParams',
-   function($scope, $rootScope, $location, $routeParams) {
+angular.module('paperworkNotes').controller('MessageBoxController', function($scope, $rootScope, $location, $routeParams) {
      $scope.onClick = function(buttonId) {
        if(typeof buttonId == "undefined" || buttonId == null || buttonId == "") {
          return false;
@@ -19,4 +17,4 @@ angular.module('paperworkNotes').controller('MessageBoxController',
          }
        }
      };
-   }]);
+   });

--- a/frontend/app/js/paperwork/messagebox/messagebox.service.js
+++ b/frontend/app/js/paperwork/messagebox/messagebox.service.js
@@ -1,7 +1,5 @@
-angular.module('paperworkNotes').factory('MessageBoxService',
-  ['$rootScope', '$http', 'NetService',
-   function($rootScope, $http, netService) {
+angular.module('paperworkNotes').factory('MessageBoxService', function($rootScope, $http, netService) {
      var paperworkMessageBoxFactory = {};
 
      return paperworkMessageBoxFactory;
-   }]);
+   });

--- a/frontend/app/js/paperwork/net/net.service.js
+++ b/frontend/app/js/paperwork/net/net.service.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').service('NetService',
-  ['$rootScope', '$http', '$location', 'paperworkApi',
-   function($rootScope, $http, $location, paperworkApi) {
+angular.module('paperworkNotes').service('NetService', function($rootScope, $http, $location, paperworkApi) {
      this.apiGeneric = function(method, url, data, callback) {
        var $opts = {method: method, url: paperworkApi + url};
        if(typeof data != "undefined" && data != null) {
@@ -37,4 +35,4 @@ angular.module('paperworkNotes').service('NetService',
      this.apiDelete = function(url, callback) {
        this.apiGeneric('DELETE', url, null, callback);
      };
-   }]);
+   });

--- a/frontend/app/js/paperwork/notebooks/notebooks.service.js
+++ b/frontend/app/js/paperwork/notebooks/notebooks.service.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').factory('NotebooksService',
-  ['$rootScope', '$http', 'NetService',
-   function($rootScope, $http, netService) {
+angular.module('paperworkNotes').factory('NotebooksService', function($rootScope, $http, netService) {
      var paperworkNotebooksServiceFactory = {};
 
      // paperworkNotebooksServiceFactory.selectedNotebookId = 0;
@@ -70,4 +68,4 @@ angular.module('paperworkNotes').factory('NotebooksService',
      };
 
      return paperworkNotebooksServiceFactory;
-   }]);
+   });

--- a/frontend/app/js/paperwork/notes/notes.service.js
+++ b/frontend/app/js/paperwork/notes/notes.service.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').factory('NotesService',
-  ['$rootScope', '$http', 'base64', 'NetService',
-   function($rootScope, $http, base64, netService) {
+angular.module('paperworkNotes').factory('NotesService', function($rootScope, $http, base64, netService) {
      var paperworkNotesServiceFactory = {};
 
      // paperworkNotesServiceFactory.selectedNoteIndex = 0;
@@ -81,4 +79,4 @@ angular.module('paperworkNotes').factory('NotesService',
      };
 
      return paperworkNotesServiceFactory;
-   }]);
+   });

--- a/frontend/app/js/paperwork/notes/notes_all.controller.js
+++ b/frontend/app/js/paperwork/notes/notes_all.controller.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').controller('NotesAllController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NotesService',
-   function($scope, $rootScope, $location, $routeParams, notesService) {
+angular.module('paperworkNotes').controller('NotesAllController', function($scope, $rootScope, $location, $routeParams, notesService) {
      if(typeof $routeParams == "undefined" || $routeParams == {} || typeof $routeParams.notebookId == "undefined") {
        return;
 
@@ -22,4 +20,4 @@ angular.module('paperworkNotes').controller('NotesAllController',
      $rootScope.expandedNoteLayout = false;
 
      $rootScope.note = null;
-   }]);
+   });

--- a/frontend/app/js/paperwork/notes/notes_edit.controller.js
+++ b/frontend/app/js/paperwork/notes/notes_edit.controller.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').controller('NotesEditController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NotesService', 'paperworkApi',
-    function($scope, $rootScope, $location, $routeParams, notesService, paperworkApi) {
+angular.module('paperworkNotes').controller('NotesEditController', function($scope, $rootScope, $location, $routeParams, notesService, paperworkApi) {
       window.onCkeditChangeFunction = function() {
         // FIXME jQuery un angular is anti-pattern
         // Let's access our $rootScope from within jQuery (this)
@@ -159,4 +157,4 @@ angular.module('paperworkNotes').controller('NotesEditController',
       $rootScope.navbarMainMenu = false;
       $rootScope.navbarSearchForm = false;
       $rootScope.expandedNoteLayout = true;
-    }]);
+    });

--- a/frontend/app/js/paperwork/notes/notes_list.controller.js
+++ b/frontend/app/js/paperwork/notes/notes_list.controller.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').controller('NotesListController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NotesService',
-    function($scope, $rootScope, $location, $routeParams, notesService) {
+angular.module('paperworkNotes').controller('NotesListController', function($scope, $rootScope, $location, $routeParams, notesService) {
     $rootScope.noteSelectedId = {};
     $rootScope.notesSelectedIds = [];
     notesService.getNotesInNotebook(0);
@@ -19,4 +17,4 @@ angular.module('paperworkNotes').controller('NotesListController',
       return path;
     };
 
-}]);
+});

--- a/frontend/app/js/paperwork/notes/notes_show.controller.js
+++ b/frontend/app/js/paperwork/notes/notes_show.controller.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').controller('NotesShowController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NotesService', 'NetService',
-   function($scope, $rootScope, $location, $routeParams, notesService, netService) {
+angular.module('paperworkNotes').controller('NotesShowController', function($scope, $rootScope, $location, $routeParams, notesService, netService) {
      if(!angular.isNumber(parseInt($routeParams.noteId)) || $routeParams.noteId === "undefined") {
        return;
      }
@@ -34,4 +32,4 @@ angular.module('paperworkNotes').controller('NotesShowController',
      $rootScope.navbarMainMenu = true;
      $rootScope.navbarSearchForm = true;
      $rootScope.expandedNoteLayout = false;
-   }]);
+   });

--- a/frontend/app/js/paperwork/search/search.controller.js
+++ b/frontend/app/js/paperwork/search/search.controller.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').controller('SearchController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NotesService',
-   function($scope, $rootScope, $location, $routeParams, notesService) {
+angular.module('paperworkNotes').controller('SearchController', function($scope, $rootScope, $location, $routeParams, notesService) {
      var sQ = $routeParams.searchQuery;
 
      $rootScope.search = sQ;
@@ -21,4 +19,4 @@ angular.module('paperworkNotes').controller('SearchController',
      $rootScope.navbarMainMenu = true;
      $rootScope.navbarSearchForm = true;
      $rootScope.expandedNoteLayout = false;
-   }]);
+   });

--- a/frontend/app/js/paperwork/sidebar/notebooks.controller.js
+++ b/frontend/app/js/paperwork/sidebar/notebooks.controller.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').controller('SidebarNotebooksController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NotebooksService',
-   function($scope, $rootScope, $location, $routeParams, notebooksService) {
+angular.module('paperworkNotes').controller('SidebarNotebooksController', function($scope, $rootScope, $location, $routeParams, notebooksService) {
      $rootScope.notebookSelectedId = 0;
      $rootScope.tagsSelectedId = -1;
 
@@ -171,4 +169,4 @@ angular.module('paperworkNotes').controller('SidebarNotebooksController',
      notebooksService.getNotebookShortcuts(null);
      notebooksService.getNotebooks();
      $rootScope.tags = notebooksService.getTags();
-   }]);
+   });

--- a/frontend/app/js/paperwork/sidebar/notes.controller.js
+++ b/frontend/app/js/paperwork/sidebar/notes.controller.js
@@ -1,5 +1,4 @@
 angular.module('paperworkNotes').controller('SidebarNotesController',
-  ['$scope', '$rootScope', '$location', '$timeout', '$routeParams', 'NotebooksService', 'NotesService',
     function($scope, $rootScope, $location, $timeout, $routeParams, notebooksService, notesService) {
       $scope.isVisible = function() {
         return !$rootScope.expandedNoteLayout;
@@ -240,4 +239,4 @@ angular.module('paperworkNotes').controller('SidebarNotesController',
           $location.path("/s/" + encodeURIComponent($scope.search));
         }
       };
-    }]);
+    });

--- a/frontend/app/js/paperwork/versions/versions.controller.js
+++ b/frontend/app/js/paperwork/versions/versions.controller.js
@@ -1,5 +1,3 @@
-angular.module('paperworkNotes').controller('VersionsController',
-  ['$scope', '$rootScope', '$location', '$timeout', '$routeParams',
-    function($scope, $rootScope, $location, $timeout, $routeParams){
+angular.module('paperworkNotes').controller('VersionsController', function($scope, $rootScope, $location, $timeout, $routeParams){
     // TODO
-    }]);
+    });

--- a/frontend/app/js/paperwork/versions/versions.service.js
+++ b/frontend/app/js/paperwork/versions/versions.service.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').factory('VersionsService',
-  ['$rootScope', '$http', 'NetService',
-   function($rootScope, $http, NetService) {
+angular.module('paperworkNotes').factory('VersionsService', function($rootScope, $http, NetService) {
      var paperworkVersionsServiceFactory = {};
 
      paperworkVersionsServiceFactory.getVersionById = function(notebookId, noteId, versionId) {
@@ -22,4 +20,4 @@ angular.module('paperworkNotes').factory('VersionsService',
      };
 
      return paperworkVersionsServiceFactory;
-   }]);
+   });

--- a/frontend/app/js/paperwork/view/view.controller.js
+++ b/frontend/app/js/paperwork/view/view.controller.js
@@ -1,7 +1,5 @@
-angular.module('paperworkNotes').controller('ViewController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NotesService',
-   function($scope, $rootScope, $location, $routeParams, notesService) {
+angular.module('paperworkNotes').controller('ViewController', function($scope, $rootScope, $location, $routeParams, notesService) {
      $scope.isVisible = function() {
        return !$rootScope.expandedNoteLayout;
      }
-   }]);
+   });

--- a/frontend/app/js/paperwork/wayback/wayback.controller.js
+++ b/frontend/app/js/paperwork/wayback/wayback.controller.js
@@ -1,6 +1,4 @@
-angular.module('paperworkNotes').controller('WaybackController',
-  ['$scope', '$rootScope', '$location', '$routeParams', 'NetService', 'NotesService',
-   function($scope, $rootScope, $location, $routeParams, netService, notesService) {
+angular.module('paperworkNotes').controller('WaybackController', function($scope, $rootScope, $location, $routeParams, netService, notesService) {
      // FIXME
      $('#paperworkViewParent').off('picked.freqselector').on('picked.freqselector', function(e) {
        var itemId = $(e.item).data('itemid');
@@ -22,4 +20,4 @@ angular.module('paperworkNotes').controller('WaybackController',
        });
 
      });
-   }]);
+   });

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -133,7 +133,7 @@ gulp.task('compileJsBootstrap', function() {
 gulp.task('compileJsPaperwork', function() {
 	gulp
 		.src(paths.paperwork)
-        .pipe(ngAnnotate())
+		.pipe(ngAnnotate())
 		.pipe(concat('paperwork.min.js'))
 		.pipe(gulp.dest(paths.output.js))
 		.pipe(livereload());

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -5,6 +5,7 @@ var rename = require('gulp-rename');
 var livereload = require('gulp-livereload');
 var uglify = require('gulp-uglify');
 var path = require("path");
+var ngAnnotate = require('gulp-ng-annotate');
 
 var paths = {
 	bootstrap: [
@@ -132,6 +133,7 @@ gulp.task('compileJsBootstrap', function() {
 gulp.task('compileJsPaperwork', function() {
 	gulp
 		.src(paths.paperwork)
+        .pipe(ngAnnotate())
 		.pipe(concat('paperwork.min.js'))
 		.pipe(gulp.dest(paths.output.js))
 		.pipe(livereload());

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
     "gulp-concat": "^2.4.2",
     "gulp-less": "^2.0.1",
     "gulp-livereload": "^3.2.0",
+    "gulp-ng-annotate": "^0.5.2",
     "gulp-rename": "^1.2.0",
     "gulp-uglify": "~1.1.0"
   }


### PR DESCRIPTION
Manual dependency annotation only causes issues. See #191 (:no_mouth:). This puts it in the build process where it belongs.