### PR TITLE
Issue 132 feature (filtering and searching)

### DIFF
--- a/frontend/app/js/paperwork/search/search.controller.js
+++ b/frontend/app/js/paperwork/search/search.controller.js
@@ -5,18 +5,8 @@ angular.module('paperworkNotes').controller('SearchController',
 
      $rootScope.search = sQ;
 
-     var searchMatch = /([a-zA-Z]+)(?:\:(\d+))?(\/.+)?/g.exec(sQ);
-     if(typeof searchMatch != "undefined" && searchMatch != null && searchMatch.length > 0) {
-       switch(searchMatch[1]) {
-         case "tagid":
-           notesService.getNotesInTag(searchMatch[2]);
-           break;
-         default:
-           notesService.getNotesFromSearch(searchMatch[0]);
-           break;
-       }
-       $rootScope.note = null;
-     }
+     notesService.getNotesFromSearch(sQ);
+     $rootScope.note = null;
 
      $rootScope.navbarMainMenu = true;
      $rootScope.navbarSearchForm = true;

--- a/frontend/app/lib/Paperwork/PaperworkHelpers.php
+++ b/frontend/app/lib/Paperwork/PaperworkHelpers.php
@@ -85,6 +85,17 @@ class PaperworkHelpers {
 		);
 		return json_encode($data);
 	}
+
+	public function cleanupMatches($string, $matches, $key = 0) {
+		foreach($matches as $match) {
+			$pos = strpos($string, $match[$key]);
+			if($pos !== false) {
+				$string = substr_replace($string, "", $pos, strlen($match[$key]));
+			}
+		}
+
+		return $string;
+	}
 }
 
 ?>


### PR DESCRIPTION
Relates to #132

Searching and filtering revisited, now allowing multiple filters and string search at the same time.

**Date filter implemented, allowing the following formats split by '-' '.' or '/':**
- date:yyyy
- date:yyyy/mm
- date:yyyy/mm/dd

**Id filter implemented, allowing the following formats:**
- noteid:x
- notebookid:x
- tagid:x
