### PR TITLE
Fix missing $this-> in apiNotesController

### DIFF
--- a/frontend/app/controllers/api/v1/ApiNotesController.php
+++ b/frontend/app/controllers/api/v1/ApiNotesController.php
@@ -160,9 +160,9 @@ class ApiNotesController extends BaseController {
 
 	public function show($notebookId, $id = null)
 	{
-		if (is_null($id ))
+		if (is_null($id))
 		{
-			return index($notebookId);
+			return $this->index($notebookId);
 		}
 		else
 		{


### PR DESCRIPTION
There's no index() function, only a $this->index() function :)