### PR TITLE
Increase note content font size and correct comments

### DIFF
--- a/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
+++ b/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
@@ -342,6 +342,10 @@ ul.nav-tabs-margin {
 .main .page-header {
   margin-top: 0;
 }
+.main .page-content {
+  font-size: @font-size-large;
+  line-height: 1.7;
+}
 
 
 /*

--- a/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-variables.less
+++ b/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-variables.less
@@ -60,8 +60,8 @@
 @font-family-base:        @font-family-sans-serif;
 
 @font-size-base:          12px;
-@font-size-large:         ceil((@font-size-base * 1.25)); // ~18px
-@font-size-small:         ceil((@font-size-base * 0.85)); // ~12px
+@font-size-large:         ceil((@font-size-base * 1.25)); // ~15px
+@font-size-small:         ceil((@font-size-base * 0.85)); // ~11px
 
 @font-size-h1:            floor((@font-size-base * 2.6)); // ~36px
 @font-size-h2:            floor((@font-size-base * 2.15)); // ~30px


### PR DESCRIPTION
12px is seriously small for main content. Even after increasing the font size to 15px, I still feel like I have to use my browser's zoom to achieve readability.

I'd advocate increasing the font size everywhere and putting a max-width of 40-60em on paragraphs, but figured that would be too big of a change for a humble pull request.

## Before
![Before](http://i.imgur.com/spQLRpi.png)

## After
![After](http://i.imgur.com/Vrb2bzt.png)