### PR TITLE
Darken disabled dropdown menu links

### DIFF
--- a/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-variables.less
+++ b/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-variables.less
@@ -245,7 +245,7 @@
 @dropdown-link-active-bg:        @component-active-bg;
 
 //** Disabled dropdown menu item background color.
-@dropdown-link-disabled-color:   @gray-light;
+@dropdown-link-disabled-color:   @gray-medium-dark;
 
 //** Text color for headers within dropdown menus.
 @dropdown-header-color:          @gray-light;


### PR DESCRIPTION
`#f5f5f5` on a white background is entirely unreadable.

Original PR: https://github.com/twostairs/paperwork/pull/283 fixed to be against develop branch.