### PR TITLE
-Version was being created twice for new notes, and one time it was send...

### DIFF
--- a/frontend/app/controllers/api/v1/ApiNotesController.php
+++ b/frontend/app/controllers/api/v1/ApiNotesController.php
@@ -250,7 +250,7 @@ class ApiNotesController extends BaseController {
 			return PaperworkHelpers::apiResponse(PaperworkHelpers::STATUS_NOTFOUND, array());
 		}
 
-		return PaperworkHelpers::apiResponse(PaperworkHelpers::STATUS_SUCCESS, $notes->toArray());
+		return PaperworkHelpers::apiResponse(PaperworkHelpers::STATUS_SUCCESS, $notes->first());
 
 	}
 
@@ -261,9 +261,7 @@ class ApiNotesController extends BaseController {
 
 		$note = new Note();
 
-		$version = new Version(array('title' => $newNote->get("title"), 'content' => $newNote->get("content"), 'content_preview' => $newNote->get("content_preview")));
-		$version->save();
-		$note->version()->associate($version);
+		
 
 		$notebook = DB::table('notebooks')
 			->join('notebook_user', function($join) {
@@ -279,8 +277,10 @@ class ApiNotesController extends BaseController {
 			return PaperworkHelpers::apiResponse(PaperworkHelpers::STATUS_NOTFOUND, array());
 		}
 
+        $version = new Version(array('title' => $newNote->get("title"), 'content' => $newNote->get("content"), 'content_preview' => $newNote->get("content_preview")));
+        $version->save();
+        $note->version()->associate($version);
 		$note->notebook_id = $notebookId;
-		$version = Version::create(array('title' => $newNote->get("title"), 'content' => $newNote->get("content")));
 		$version->save();
 
 		$note->save();
@@ -323,7 +323,8 @@ class ApiNotesController extends BaseController {
 
 			// TODO: This is a temporary workaround for the content_preview. We need to check, whether there is content or at least one attachment.
 			// If there's no content, parse the attachment and set the result as content_preview. This should somehow be done within the DocumentParser, I guess.
-			$version = new Version(array('title' => $updateNote->get("title"), 'content' => $updateNote->get("content"), 'content_preview' => strip_tags($updateNote->get("content"))));
+			$version = new Version(array('title' => $updateNote->get("title"), 'content' => $updateNote->get("content"),
+                'content_preview' => substr(strip_tags($updateNote->get("content")),0,255)));
 			$version->save();
 
 

--- a/frontend/app/database/migrations/2014_07_22_194050_initialize.php
+++ b/frontend/app/database/migrations/2014_07_22_194050_initialize.php
@@ -13,7 +13,6 @@ class Initialize extends Migration {
 	public function up()
 	{
 		Schema::create('users', function(Blueprint $table) {
-            // $table->bigIncrements('id')->unsigned();
             $table->char('id', 36)->default(NULL)->primary();
             $table->string('username')->unique();
             $table->string('password');
@@ -26,8 +25,7 @@ class Initialize extends Migration {
         });
 
         Schema::create('settings', function(Blueprint $table) {
-            $table->bigIncrements('id')->unsigned();
-            // $table->bigInteger('user_id')->unsigned();
+            $table->char('id', 36)->default(NULL)->primary();
             $table->char('user_id', 36);
             $table->foreign('user_id')->references('id')->on('users');
             $table->char('ui_language', 2);
@@ -37,91 +35,88 @@ class Initialize extends Migration {
         });
 
         Schema::create('languages', function(Blueprint $table) {
-            $table->bigIncrements('id')->unsigned();
+            $table->char('id', 36)->default(NULL)->primary();
             $table->char('language_code', 7);
             $table->timestamps();
             $table->softDeletes();
             $table->engine = 'InnoDB';
         });
 
-        DB::table('languages')->insert(array('language_code' => 'afr'));
-        DB::table('languages')->insert(array('language_code' => 'ara'));
-        DB::table('languages')->insert(array('language_code' => 'aze'));
-        DB::table('languages')->insert(array('language_code' => 'bel'));
-        DB::table('languages')->insert(array('language_code' => 'ben'));
-        DB::table('languages')->insert(array('language_code' => 'bul'));
-        DB::table('languages')->insert(array('language_code' => 'cat'));
-        DB::table('languages')->insert(array('language_code' => 'ces'));
-        DB::table('languages')->insert(array('language_code' => 'chi-sim'));
-        DB::table('languages')->insert(array('language_code' => 'chi-tra'));
-        DB::table('languages')->insert(array('language_code' => 'chr'));
-        DB::table('languages')->insert(array('language_code' => 'dan'));
-        DB::table('languages')->insert(array('language_code' => 'deu'));
-        DB::table('languages')->insert(array('language_code' => 'ell'));
-        DB::table('languages')->insert(array('language_code' => 'eng'));
-        DB::table('languages')->insert(array('language_code' => 'enm'));
-        DB::table('languages')->insert(array('language_code' => 'epo'));
-        DB::table('languages')->insert(array('language_code' => 'equ'));
-        DB::table('languages')->insert(array('language_code' => 'est'));
-        DB::table('languages')->insert(array('language_code' => 'eus'));
-        DB::table('languages')->insert(array('language_code' => 'fin'));
-        DB::table('languages')->insert(array('language_code' => 'fra'));
-        DB::table('languages')->insert(array('language_code' => 'frk'));
-        DB::table('languages')->insert(array('language_code' => 'frm'));
-        DB::table('languages')->insert(array('language_code' => 'glg'));
-        DB::table('languages')->insert(array('language_code' => 'grc'));
-        DB::table('languages')->insert(array('language_code' => 'heb'));
-        DB::table('languages')->insert(array('language_code' => 'hin'));
-        DB::table('languages')->insert(array('language_code' => 'hrv'));
-        DB::table('languages')->insert(array('language_code' => 'hun'));
-        DB::table('languages')->insert(array('language_code' => 'ind'));
-        DB::table('languages')->insert(array('language_code' => 'isl'));
-        DB::table('languages')->insert(array('language_code' => 'ita'));
-        DB::table('languages')->insert(array('language_code' => 'jpn'));
-        DB::table('languages')->insert(array('language_code' => 'kan'));
-        DB::table('languages')->insert(array('language_code' => 'kor'));
-        DB::table('languages')->insert(array('language_code' => 'lav'));
-        DB::table('languages')->insert(array('language_code' => 'lit'));
-        DB::table('languages')->insert(array('language_code' => 'mal'));
-        DB::table('languages')->insert(array('language_code' => 'mkd'));
-        DB::table('languages')->insert(array('language_code' => 'mlt'));
-        DB::table('languages')->insert(array('language_code' => 'msa'));
-        DB::table('languages')->insert(array('language_code' => 'nld'));
-        DB::table('languages')->insert(array('language_code' => 'nor'));
-        DB::table('languages')->insert(array('language_code' => 'pol'));
-        DB::table('languages')->insert(array('language_code' => 'por'));
-        DB::table('languages')->insert(array('language_code' => 'ron'));
-        DB::table('languages')->insert(array('language_code' => 'rus'));
-        DB::table('languages')->insert(array('language_code' => 'slk'));
-        DB::table('languages')->insert(array('language_code' => 'slv'));
-        DB::table('languages')->insert(array('language_code' => 'spa'));
-        DB::table('languages')->insert(array('language_code' => 'sqi'));
-        DB::table('languages')->insert(array('language_code' => 'srp'));
-        DB::table('languages')->insert(array('language_code' => 'swa'));
-        DB::table('languages')->insert(array('language_code' => 'swe'));
-        DB::table('languages')->insert(array('language_code' => 'tam'));
-        DB::table('languages')->insert(array('language_code' => 'tel'));
-        DB::table('languages')->insert(array('language_code' => 'tgl'));
-        DB::table('languages')->insert(array('language_code' => 'tha'));
-        DB::table('languages')->insert(array('language_code' => 'tur'));
-        DB::table('languages')->insert(array('language_code' => 'ukr'));
-        DB::table('languages')->insert(array('language_code' => 'vie'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'afr'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'ara'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'aze'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'bel'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'ben'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'bul'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'cat'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'ces'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'chi-sim'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'chi-tra'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'chr'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'dan'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'deu'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'ell'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'eng'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'enm'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'epo'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'equ'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'est'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'eus'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'fin'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'fra'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'frk'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'frm'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'glg'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'grc'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'heb'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'hin'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'hrv'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'hun'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'ind'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'isl'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'ita'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'jpn'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'kan'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'kor'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'lav'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'lit'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'mal'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'mkd'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'mlt'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'msa'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'nld'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'nor'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'pol'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'por'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'ron'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'rus'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'slk'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'slv'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'spa'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'sqi'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'srp'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'swa'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'swe'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'tam'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'tel'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'tgl'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'tha'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'tur'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'ukr'));
+        DB::table('languages')->insert(array('id'=> \Uuid::generate(4),'language_code' => 'vie'));
 
         Schema::create('language_user', function(Blueprint $table) {
             $table->bigIncrements('id')->unsigned();
-            // $table->bigInteger('user_id')->unsigned();
             $table->char('user_id', 36);
             $table->foreign('user_id')->references('id')->on('users');
-            $table->bigInteger('language_id')->unsigned();
+            $table->char('language_id', 36);
             $table->foreign('language_id')->references('id')->on('languages')->onDelete('cascade');
             $table->timestamps();
             $table->engine = 'InnoDB';
         });
 
-		Schema::create('notebooks', function(Blueprint $table) {
-            // $table->bigIncrements('id')->unsigned();
+        Schema::create('notebooks', function(Blueprint $table) {
             $table->char('id', 36)->default(NULL)->primary();
-            // $table->bigInteger('parent_id')->unsigned()->nullable();
             $table->char('parent_id', 36)->nullable();
             $table->tinyInteger('type')->unsigned()->default(0);
             $table->string('title');
@@ -129,14 +124,14 @@ class Initialize extends Migration {
             $table->softDeletes();
             $table->engine = 'InnoDB';
         });
-        DB::statement('ALTER TABLE notebooks ADD FOREIGN KEY (parent_id) REFERENCES notebooks (id) ON DELETE CASCADE ON UPDATE CASCADE');
+        Schema::table('notebooks', function(Blueprint $table){
+            $table->foreign("parent_id")->references("id")->on("notebooks")->onDelete('cascade')->onUpdate("cascade");
+        });
 
         Schema::create('notebook_user', function(Blueprint $table) {
             $table->bigIncrements('id')->unsigned();
-            // $table->bigInteger('user_id')->unsigned();
             $table->char('user_id', 36);
             $table->foreign('user_id')->references('id')->on('users');
-            // $table->bigInteger('notebook_id')->unsigned();
             $table->char('notebook_id', 36);
             $table->foreign('notebook_id')->references('id')->on('notebooks')->onDelete('cascade');
             $table->tinyInteger('umask');
@@ -145,11 +140,8 @@ class Initialize extends Migration {
         });
 
         Schema::create('versions', function(Blueprint $table) {
-            // $table->bigIncrements('id')->unsigned();
             $table->char('id', 36)->default(NULL)->primary();
-            // $table->bigInteger('previous_id')->unsigned()->nullable();
             $table->char('previous_id', 36)->nullable();
-            // $table->bigInteger('next_id')->unsigned()->nullable();
             $table->char('next_id', 36)->nullable();
             $table->string('title');
             $table->string('content_preview');
@@ -158,12 +150,12 @@ class Initialize extends Migration {
             $table->softDeletes();
             $table->engine = 'InnoDB';
         });
-        DB::statement('ALTER TABLE versions ADD FOREIGN KEY (previous_id) REFERENCES versions (id) ON DELETE SET NULL ON UPDATE CASCADE');
-        DB::statement('ALTER TABLE versions ADD FOREIGN KEY (next_id) REFERENCES versions (id) ON DELETE SET NULL ON UPDATE CASCADE');
-        // DB::statement('ALTER TABLE versions ADD FULLTEXT search(title, content)');
+        Schema::table('versions', function(Blueprint $table) {
+            $table->foreign("previous_id")->references("id")->on("versions")->onDelete('set null')->onUpdate("cascade");
+            $table->foreign("next_id")->references("id")->on("versions")->onDelete('set null')->onUpdate("cascade");
+        });
 
         Schema::create('attachments', function(Blueprint $table) {
-            // $table->bigIncrements('id')->unsigned();
             $table->char('id', 36)->default(NULL)->primary();
             $table->timestamps();
             $table->string('filename');
@@ -174,28 +166,21 @@ class Initialize extends Migration {
             $table->softDeletes();
             $table->engine = 'InnoDB';
         });
-        // DB::statement('ALTER TABLE attachments ADD FULLTEXT search(content)');
 
         Schema::create('attachment_version', function(Blueprint $table) {
-            // $table->bigIncrements('id')->unsigned();
-            $table->char('id', 36)->default(NULL)->primary();
-            // $table->bigInteger('attachment_id')->unsigned();
+            $table->bigIncrements('id')->unsigned();
             $table->char('attachment_id', 36);
             $table->foreign('attachment_id')->references('id')->on('attachments')->onDelete('cascade');
-            // $table->bigInteger('version_id')->unsigned();
             $table->char('version_id', 36);
             $table->foreign('version_id')->references('id')->on('versions')->onDelete('cascade');
             $table->timestamps();
             $table->engine = 'InnoDB';
         });
 
-		Schema::create('notes', function(Blueprint $table) {
-            // $table->bigIncrements('id')->unsigned();
+        Schema::create('notes', function(Blueprint $table) {
             $table->char('id', 36)->default(NULL)->primary();
-            // $table->bigInteger('notebook_id')->unsigned();
             $table->char('notebook_id', 36);
             $table->foreign('notebook_id')->references('id')->on('notebooks');
-            // $table->bigInteger('version_id')->unsigned();
             $table->char('version_id', 36);
             $table->foreign('version_id')->references('id')->on('versions');
             $table->timestamps();
@@ -205,10 +190,8 @@ class Initialize extends Migration {
 
         Schema::create('note_user', function(Blueprint $table) {
             $table->bigIncrements('id')->unsigned();
-            // $table->bigInteger('user_id')->unsigned();
             $table->char('user_id', 36);
             $table->foreign('user_id')->references('id')->on('users');
-            // $table->bigInteger('note_id')->unsigned();
             $table->char('note_id', 36);
             $table->foreign('note_id')->references('id')->on('notes')->onDelete('cascade');
             $table->tinyInteger('umask');
@@ -218,7 +201,6 @@ class Initialize extends Migration {
 
 		Schema::create('tags', function(Blueprint $table) {
             $table->char('id', 36)->default(NULL)->primary();
-            // $table->bigIncrements('id')->unsigned();
             $table->string('title');
             $table->timestamps();
             $table->softDeletes();
@@ -227,10 +209,8 @@ class Initialize extends Migration {
 
         Schema::create('tag_user', function(Blueprint $table) {
             $table->bigIncrements('id')->unsigned();
-            // $table->bigInteger('user_id')->unsigned();
             $table->char('user_id', 36);
             $table->foreign('user_id')->references('id')->on('users');
-            // $table->bigInteger('tag_id')->unsigned();
             $table->char('tag_id', 36);
             $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
             $table->timestamps();
@@ -239,10 +219,8 @@ class Initialize extends Migration {
 
         Schema::create('tag_note', function(Blueprint $table) {
             $table->bigIncrements('id')->unsigned();
-            // $table->bigInteger('note_id')->unsigned();
             $table->char('note_id', 36);
             $table->foreign('note_id')->references('id')->on('notes')->onDelete('cascade');
-            // $table->bigInteger('tag_id')->unsigned();
             $table->char('tag_id', 36);
             $table->foreign('tag_id')->references('id')->on('tags')->onDelete('cascade');
             $table->timestamps();
@@ -250,11 +228,9 @@ class Initialize extends Migration {
         });
 
         Schema::create('shortcuts', function(Blueprint $table) {
-            $table->bigIncrements('id')->unsigned();
-            // $table->bigInteger('user_id')->unsigned();
+            $table->char('id', 36)->default(NULL)->primary();
             $table->char('user_id', 36);
             $table->foreign('user_id')->references('id')->on('users');
-            // $table->bigInteger('notebook_id')->unsigned();
             $table->char('notebook_id', 36);
             $table->foreign('notebook_id')->references('id')->on('notebooks')->onDelete('cascade');
             $table->tinyInteger('sortkey')->unsigned();

--- a/frontend/app/js/paperwork/sidebar/notes.controller.js
+++ b/frontend/app/js/paperwork/sidebar/notes.controller.js
@@ -81,11 +81,11 @@ angular.module('paperworkNotes').controller('SidebarNotesController',
       //   $rootScope.templateNoteEdit = {};
       // }
 
-      $rootScope.templateNoteEdit.content = CKEDITOR.instances.content.getData();
+      $rootScope.templateNoteEdit.version.content = CKEDITOR.instances.content.getData();
 
       var data = {
-        'title':   $rootScope.templateNoteEdit.title,
-        'content': $rootScope.templateNoteEdit.content,
+        'title':   $rootScope.templateNoteEdit.version.title,
+        'content': $rootScope.templateNoteEdit.version.content,
         'tags':    $('input#tags').tagsinput('items')
       };
 

--- a/frontend/app/lib/Paperwork/Db/PaperworkDbNoteObject.php
+++ b/frontend/app/lib/Paperwork/Db/PaperworkDbNoteObject.php
@@ -7,9 +7,11 @@ use Illuminate\Config\Repository;
 class PaperworkDbNoteObject extends PaperworkDbObject {
 
 	public function get($argv = array()) {
-		$defaultNotesSelect = array('notes.id', 'notes.notebook_id', 'notes.created_at', 'notes.updated_at');
-		$defaultVersionsSelect = array('versions.title', 'versions.content_preview', 'versions.content');
-		$defaultTagsSelect = array('tags.visibility', 'tags.title');
+        //the version_id has to be included here or the eager load below will fail
+        //also, all off the ids of the relationships have to be here also, or it will also fail
+		$defaultNotesSelect = array('notes.id', 'notes.notebook_id', 'notes.created_at', 'notes.updated_at','notes.version_id');
+		$defaultVersionsSelect = array('versions.id','versions.title', 'versions.content_preview', 'versions.content');
+		$defaultTagsSelect = array('tags.id','tags.visibility', 'tags.title');
 
 		$userId = $this->getArg($argv, 'userid');
 		$id = $this->getArg($argv, 'id');
@@ -36,7 +38,7 @@ class PaperworkDbNoteObject extends PaperworkDbObject {
 				$data->orWhere('notes.id', '=', $argv['id'][$i]);
 			}
 		}
-		if(isset($notebookId)) {
+		if(isset($notebookId) && $notebookId != \PaperworkDb::DB_ALL_ID) {
 			$data->where('notes.notebook_id', '=', $notebookId);
 		}
 		$data->whereNull('deleted_at');

--- a/frontend/app/views/main.blade.php
+++ b/frontend/app/views/main.blade.php
@@ -63,13 +63,13 @@
 					</div>
 					<a class="{{ editMultipleNotes ? 'col-sm-11' : '' }}" href="#{{getNoteLink(note.notebook_id, note.id)}}">
 						<div class="">
-							<span class="notes-list-title notes-list-title-gradient">{{note.title}}</span>
+							<span class="notes-list-title notes-list-title-gradient">{{note.version.title}}</span>
 							<span class="notes-list-date">
 								<span class="notes-list-date-day">{{note.updated_at | convertdate | date : 'd'}}</span>
 								<span class="notes-list-date-month">{{note.updated_at | convertdate | date : 'MMM'}}</span>
 								<span class="notes-list-date-year">{{note.updated_at | convertdate | date : 'yyyy'}}</span>
 							</span>
-							<span class="notes-list-content notes-list-content-gradient" ng-bind-html="note.content_preview"></span>
+							<span class="notes-list-content notes-list-content-gradient" ng-bind-html="note.version.content_preview"></span>
 						</div>
 					</a>
 					<div class="clear"></div>

--- a/frontend/app/views/templates/paperworkNoteEdit.blade.php
+++ b/frontend/app/views/templates/paperworkNoteEdit.blade.php
@@ -29,14 +29,14 @@
 					<div>
 						<div class="page-header">
 							<div class="form-group {{ errors.title ? 'has-error' : '' }}">
-								<input type="text" class="form-control input-lg" id="title" placeholder="[[Lang::get('keywords.note_title')]]" ng-model="templateNoteEdit.title">
+								<input type="text" class="form-control input-lg" id="title" placeholder="[[Lang::get('keywords.note_title')]]" ng-model="templateNoteEdit.version.title">
 							</div>
 							<div class="form-group {{ errors.tags ? 'has-error' : '' }}">
 								<input type="text" class="form-control input-lg" id="tags" placeholder="[[Lang::get('keywords.tags_separated')]]">
 							</div>
 						</div>
 						<div class="page-content">
-							<textarea id="content" class="form-control" rows="16" ng-model="templateNoteEdit.content"></textarea>
+							<textarea id="content" class="form-control" rows="16" ng-model="templateNoteEdit.version.content"></textarea>
 						</div>
 					</div>
 				</form>

--- a/frontend/app/views/templates/paperworkNoteShow.blade.php
+++ b/frontend/app/views/templates/paperworkNoteShow.blade.php
@@ -61,13 +61,13 @@
 	[[Lang::get('messages.note_version_info')]]
 	</div>
 	<div class="page-header">
-		<h1>{{note.title}}</h1>
+		<h1>{{note.version.title}}</h1>
 		<div class="note-tags-bar">
 			<span ng-repeat="tag in note.tags" ng-click="openTag(tag.id)"class="label label-tag label-tag-{{ tag.visibility < 1 ? 'private' : 'public' }}"><i class="fa fa-tags"></i> {{ tag.title }}</span>
 		</div>
 	</div>
 
-	<div class="page-content" ng-bind-html="note.content">
+	<div class="page-content" ng-bind-html="note.version.content">
 	</div>
 </div>
 	@include('partials/file-uploader', array('uploadEnabled' => false, 'actionsEnabled' => false))


### PR DESCRIPTION
fixes #294 

-show on specific note id was returning an array of one element always
-content_preview was set to all content on update, making it not save. It's not substr to 255 to match the length of the column.
-converted all of the id columns on the  tables for the paperwork models in the initial migration to char(36) so that the uuid will actually fit. join tables still have a bigIncrements id.
-added uuid to the languages inserts.
-changed angular/template stuff to access note data through the version instead of the note directly, because that's where the stuff is.
-fixed the eloquent query to load the note with the version on the paperworkDbNoteObject
-made the paperworkDbNoteObject::get return all notes in all notebooks if the notebook id is set to the DB_ALL_ID