### PR TITLE
Generic htaccess, composer.json and package.json updated

### DIFF
--- a/frontend/.htaccess
+++ b/frontend/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteCond %{REQUEST_URI} !paperwork/frontend/public/
+RewriteRule (.*) /paperwork/frontend/public/$1 [L]

--- a/frontend/composer.json
+++ b/frontend/composer.json
@@ -32,6 +32,7 @@
 		],
 		"post-update-cmd": [
 			"php artisan clear-compiled",
+            "php artisan ide-helper:generate",
 			"php artisan optimize"
 		],
 		"post-create-project-cmd": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
     "gulp": "^3.8.10",
     "gulp-concat": "^2.4.2",
     "gulp-jshint": "^1.9.2",
-    "gulp-less": "^2.0.1",
+    "gulp-less": "2.0.1",
     "gulp-livereload": "^3.2.0",
     "gulp-ng-annotate": "^0.5.2",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
I believe it would be beneficial for people not to have to manually create the .htaccess file everytime that they are setting up their paperwork app and so I have created a .htaccess following the instructions on https://github.com/twostairs/paperwork#initial-installation-quick--dirty-documented 

Also since we are using Barrys amazing IDE helper I have also added the "php artisan ide-helper:generate" to the composer update command. I have left out the Service provider this time since someone who would be doing a composer update most probably would be a developer and therefore having the ide generate there would be helpful by default but they can always add the service provider by themselves. 

On the other hand if you want I can also add the Service Provider and resubmit the pull request