### PR TITLE
Reduce logo size to make readme more compact

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Paperwork - OpenSource note-taking & archiving
 [![Join the chat at https://gitter.im/twostairs/paperwork](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/twostairs/paperwork?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/twostairs/paperwork.svg?branch=master)](https://travis-ci.org/twostairs/paperwork)
 
-![paperwork-logo](https://raw.githubusercontent.com/twostairs/paperwork/master/paperwork-logo.png)
+<img src="https://raw.githubusercontent.com/twostairs/paperwork/master/paperwork-logo.png" width="250" align="left" />
 
 Paperwork aims to be an open-source, self-hosted alternative to services like Evernote (R), Microsoft OneNote (R) or Google Keep (R).
 


### PR DESCRIPTION
Current README consist of a huge logo and some text below, and it is frustrating to scroll one full-hd screen down to get to the text. 
This proposal makes it left-floating 250px-wide image near the introduction.