### PR TITLE
Check for commit timestamps and branches during update check

### DIFF
--- a/frontend/app/lang/en/messages.php
+++ b/frontend/app/lang/en/messages.php
@@ -8,7 +8,8 @@ return array(
 	'note_version_info' => 'You are previewing an older version of this note.',
 	'found_bug' => 'Found a bug? <a href="https://github.com/twostairs/paperwork/issues/new" target="_blank" title="Submit Issue">Submit it on GitHub!</a>',
 	'new_version_available' => 'Found a bug? It seems like you are not running the latest version of Paperwork. Please consider updating before submitting an issue. ',
-	'error_version_check' => 'Found a bug? Paperwork cannot check whether your version is the latest. Please make sure you are running the latest version before reporting any issues. ', 
+	'error_version_check' => 'Found a bug? Paperwork cannot check whether your version is the latest. Please make sure you are running the latest version before reporting any issues. ',
+	'found_bug_newer_commit_installed' => 'Found a bug? It seems like you have done some changes to the Paperwork code. Before opening a new issue, please check if this issue is present in the official source code available in our Github repository. ',
 	'error_message' => 'Whooops!',
 	'onbeforeunload_info' => 'Data will be lost if you leave the page, are you sure?',
 	'user' => array(

--- a/frontend/app/lib/Paperwork/Helpers/PaperworkHelpers.php
+++ b/frontend/app/lib/Paperwork/Helpers/PaperworkHelpers.php
@@ -216,7 +216,7 @@ class PaperworkHelpers {
 
                 if (isset($jsonResult->object->sha)) {
                     $upstreamHeadSha1 = str_replace('"', '', $jsonResult->object->sha);
-                    $commit_url = $jsonResult->object->url;
+                    $commit_url = isset($jsonResult->object->url) ? $jsonResult->object->url : "";
                 } else {
                     $upstreamHeadSha1 = "";
                     $commit_url = "";
@@ -244,7 +244,7 @@ class PaperworkHelpers {
                     $jsonFromApiTimestamp = [];
                     $jsonFromApiTimestamp[] = json_decode($contentTimestamp);
                     $jsonResultTimestamp = $jsonFromApiTimestamp[0];
-                    $upstreamTimestamp = $jsonResultTimestamp->committer->date;
+                    $upstreamTimestamp = isset($jsonResultTimestamp->committer->date) ? $jsonResultTimestamp->committer->date : 0;
                 }
 
                 // Check for update daily(UTC).

--- a/frontend/app/lib/Paperwork/Helpers/PaperworkHelpers.php
+++ b/frontend/app/lib/Paperwork/Helpers/PaperworkHelpers.php
@@ -190,7 +190,7 @@ class PaperworkHelpers {
 
         if (!$cachedInfo[0] && !$cachedInfo[1]) {
             $resolver = strtolower(substr(PHP_OS, 0, 3)) == 'win' ? 'where.exe' : 'command -v';
-	    $gitOutput = "";
+            $gitOutput = "";
             exec("$resolver git", $gitOutput);
 
             if (!empty($gitOutput) && (function_exists('curl_init') !== false)) {
@@ -203,6 +203,12 @@ class PaperworkHelpers {
                 curl_setopt($ch, CURLOPT_USERAGENT, "Colorado");
 
                 $content = curl_exec($ch);
+                
+                /* Check if user is in a branch not found in Paperwork's source code */
+                $info = curl_getinfo($ch);
+                if($info["http_code"] != 200) {
+                    return [0, 0, 0, 0];
+                }
 
                 $jsonFromApi   = array();
                 $jsonFromApi[] = json_decode($content);
@@ -210,8 +216,10 @@ class PaperworkHelpers {
 
                 if (isset($jsonResult->object->sha)) {
                     $upstreamHeadSha1 = str_replace('"', '', $jsonResult->object->sha);
+                    $commit_url = $jsonResult->object->url;
                 } else {
                     $upstreamHeadSha1 = "";
+                    $commit_url = "";
                 }
 
                 // Retrieve last commit on install.
@@ -224,6 +232,20 @@ class PaperworkHelpers {
 
                     $localLatestSha1 = trim(end($matchSeparated));
                 }
+                
+                $localTimestamp = "";
+                $upstreamTimestamp = "";
+                
+                // If user is not running latest official source code, check if last commit installed is earlier than last on git 
+                if($localLatestSha1 !== $upstreamHeadSha1){
+                    $localTimestamp = exec("git show -s --format=%ci $localLatestSha1");
+                    curl_setopt($ch, CURLOPT_URL, $commit_url);
+                    $contentTimestamp = curl_exec($ch);
+                    $jsonFromApiTimestamp = [];
+                    $jsonFromApiTimestamp[] = json_decode($contentTimestamp);
+                    $jsonResultTimestamp = $jsonFromApiTimestamp[0];
+                    $upstreamTimestamp = $jsonResultTimestamp->committer->date;
+                }
 
                 // Check for update daily(UTC).
                 $now = Carbon::now();
@@ -232,7 +254,7 @@ class PaperworkHelpers {
 
                 \Cache::put(
                     'paperwork.commitInfo',
-                    [$localLatestSha1, $upstreamHeadSha1],
+                    [$localLatestSha1, $upstreamHeadSha1, $localTimestamp, $upstreamTimestamp],
                     $now->diffInMinutes($tomorrow));
             }
 

--- a/frontend/app/lib/Paperwork/Helpers/PaperworkHelpers.php
+++ b/frontend/app/lib/Paperwork/Helpers/PaperworkHelpers.php
@@ -234,7 +234,7 @@ class PaperworkHelpers {
                 }
                 
                 $localTimestamp = "";
-                $upstreamTimestamp = "";
+                $upstreamTimestamp = ""; 
                 
                 // If user is not running latest official source code, check if last commit installed is earlier than last on git 
                 if($localLatestSha1 !== $upstreamHeadSha1){

--- a/frontend/app/views/partials/error-reporting-footer.blade.php
+++ b/frontend/app/views/partials/error-reporting-footer.blade.php
@@ -1,7 +1,7 @@
 <div class="error-reporting">
     <?php
 
-    list($lastCommitOnInstall, $upstreamLatest) = PaperworkHelpers::getHashes();
+    list($lastCommitOnInstall, $upstreamLatest, $lastCommitTimestamp, $upstreamTimestamp) = PaperworkHelpers::getHashes();
     ?>
     @if(empty($lastCommitOnInstall))
         <div class="alert alert-warning" role="alert">
@@ -11,6 +11,9 @@
         <div class="alert alert-warning" role="alert">
             <p>[[Lang::get('messages.found_bug')]]</p>
         </div>
+    @elseif(strtotime($lastCommitTimestamp) > strtotime($upstreamTimestamp))
+        <div class="alert alert-warning" role="alert">
+            <p>[[Lang::get('messages.found_bug_newer_commit_installed')]]
     @else
         <div class="alert alert-danger" role="alert">
             <p>[[Lang::get('messages.new_version_available')]]


### PR DESCRIPTION
This pull request is meant to fix #330. It also triggers the error_version_check text when the user is in a branch named differently from any other branch in the Paperwork Github repository. 