### PR TITLE
Issue #265

### DIFF
--- a/frontend/app/less/bootstrap/type.less
+++ b/frontend/app/less/bootstrap/type.less
@@ -297,6 +297,6 @@ blockquote.pull-right {
 // Addresses
 address {
   margin-bottom: @line-height-computed;
-  font-style: normal;
+//  font-style: normal; // addresses are usually rendered as italic (that is also the case in ckeditor)
   line-height: @line-height-base;
 }

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -21,7 +21,6 @@
     "angular-animate": "~1.2",
     "angular-resource": "~1.2",
     "angular-route": "~1.2",
-    "angular-sanitize": "~1.2",
     "jquery": "~1.11"
   },
   "dependencies": {
@@ -29,7 +28,6 @@
     "angular-animate": "~1.2",
     "angular-route": "~1.2",
     "angular-resource": "~1.2",
-    "angular-sanitize": "~1.2",
     "angular-file-upload": "~1.1.5",
     "jquery": "~1.11",
     "angular-utf8-base64": "~0.0.5",
@@ -45,6 +43,7 @@
     "typeahead.js": "~0.10.5",
     "bootstrap3-ie10-viewport-bug-workaround": "~1.0.0",
     "angular-loading-bar": "~0.7.1",
-    "placeholders": "~4.0.1"
+    "placeholders": "~4.0.1",
+    "textAngular": "~1.3.0"
   }
 }

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -26,14 +26,15 @@ var paths = {
         'app/js/bower_components/angular/angular.js',
         'app/js/bower_components/angular-resource/angular-resource.js',
         'app/js/bower_components/angular-route/angular-route.js',
-        'app/js/bower_components/angular-sanitize/angular-sanitize.js',
+        //'app/js/bower_components/angular-sanitize/angular-sanitize.js',
         'app/js/bower_components/angular-animate/angular-animate.js',
         'app/js/bower_components/angular-file-upload/angular-file-upload.js',
         'app/js/bower_components/angular-utf8-base64/angular-utf8-base64.js',
         'app/js/bower_components/angular-ui-bootstrap-bower/ui-bootstrap.js',
         'app/js/bower_components/angular-ui-bootstrap-bower/ui-bootstrap-tpls.js',
         'app/js/bower_components/ngDraggable/ngDraggable.js',
-        'app/js/bower_components/angular-loading-bar/src/loading-bar.js'
+        'app/js/bower_components/angular-loading-bar/src/loading-bar.js',
+	'app/js/bower_components/textAngular/src/textAngular-sanitize.js'
     ],
     jQuery: [
         'app/js/bower_components/jquery/dist/jquery.js',


### PR DESCRIPTION
Following discussion in PR #443 this branch aims at replacing angular-sanitize by textAngular-sanitize. The latter allows inline style attributes (only colour, background-colour, text-align, float, width, height).

This answers to issue #265.
Later CKeditor could be replace with textAngular.