### PR TITLE
Fixed #109: Added Syntax Highlighting to code snippets

### DIFF
--- a/frontend/app/views/layouts/user-layout.blade.php
+++ b/frontend/app/views/layouts/user-layout.blade.php
@@ -15,6 +15,8 @@
     [[ HTML::style('css/mathquill.css')]]
     
     [[ HTML::style('css/loading-bar.css') ]]
+    
+    [[ HTML::style('ckeditor/plugins/codesnippet/lib/highlight/styles/default.css') ]]
 
     [[ HTML::style('//cdnjs.cloudflare.com/ajax/libs/x-editable/1.5.0/bootstrap3-editable/css/bootstrap-editable.css') ]]
 

--- a/frontend/app/views/templates/paperworkNoteShow.blade.php
+++ b/frontend/app/views/templates/paperworkNoteShow.blade.php
@@ -99,6 +99,12 @@
 
             <div class="page-content" ng-bind-html="note.version.content">
             </div>
+            <script type="text/javascript">
+                /* This is not ideal but I did not find any way to trigger code when binding finishes */
+                setTimeout(function() {
+                    hljs.initHighlighting();
+                }, 5000);
+            </script>
         </div>
     </div>
     @include('partials/file-uploader', array('uploadEnabled' => false, 'actionsEnabled' => false))


### PR DESCRIPTION
I am using a timeout for this feature. Even though I understand this is not ideal, I wasn't able to find another way to run code when binding has finished. 