### PR TITLE
Fixes export if only one note is there

### DIFF
--- a/frontend/app/controllers/UserController.php
+++ b/frontend/app/controllers/UserController.php
@@ -468,7 +468,9 @@ class UserController extends BaseController
 
             if ($noteNumber == 1) {
                 $noteArray['start'] = 1;
-            } elseif ($noteNumber == $noteCount) {
+            } 
+            
+            if ($noteNumber == $noteCount) {
                 $noteArray['end'] = 1;
             }
 


### PR DESCRIPTION
The ```elseif``` caused an issue when there was only one note as in this case both ```start``` and ```end``` must be true.

Fixes https://github.com/twostairs/paperwork/issues/480