### PR TITLE
Misspelling of "encoding" in exports

### DIFF
--- a/frontend/app/views/user/settings/export_file.blade.php
+++ b/frontend/app/views/user/settings/export_file.blade.php
@@ -32,7 +32,7 @@
     @if(isset($attachments))
     @foreach ($attachments as $attachment)
         <resource>
-        <data enconding="base64">[[ $attachment['encoded'] ]]</data><mime>[[ $attachment['mimetype'] ]]</mime>
+        <data encoding="base64">[[ $attachment['encoded'] ]]</data><mime>[[ $attachment['mimetype'] ]]</mime>
         <width>0</width><height>0</height>
         <resource-attributes><file-name>[[ $attachment['filename'] ]]</file-name></resource-attributes>
         </resource>


### PR DESCRIPTION
Doesn't cause any issues so far but might in the future. /ht @erikmaarten

See: https://github.com/JamborJan/paperwork/issues/29