### PR TITLE
Fix sidebar collapse switch issues

### DIFF
--- a/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
+++ b/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
@@ -347,7 +347,8 @@ label {
     border-right: 1px solid @gray;
   }
   .sidebar-collapse-switch {
-    left: -20px;
+    left: -35px;
+    padding: 5px;
     margin-top: 10px;
     z-index: 9999;
     display: block;
@@ -355,7 +356,7 @@ label {
     position: fixed;
   }
   .sidebar-collapse-switch-closed {
-      left: 20px;
+      left: 15px;
   }
   .sidebar-collapsed-notes-list {
       margin-left: 25px !important;

--- a/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
+++ b/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
@@ -346,11 +346,19 @@ label {
     background-color: @white;
     border-right: 1px solid @gray;
   }
-  .sidebar-collapse-switch{
+  .sidebar-collapse-switch {
     left: -20px;
+    margin-top: 10px;
+    z-index: 9999;
     display: block;
     cursor: pointer;
     position: fixed;
+  }
+  .sidebar-collapse-switch-closed {
+      left: 20px;
+  }
+  .sidebar-collapsed-notes-list {
+      margin-left: 25px !important;
   }
 }
 

--- a/frontend/app/views/main.blade.php
+++ b/frontend/app/views/main.blade.php
@@ -12,11 +12,11 @@
 <div class="container-fluid">
 	<div class="row">
         <section pw-status-notification></section>
-		<div id="sidebarNotebooks" class="col-sm-3 col-md-2 sidebar hidden-xs animate-panel disable-selection" ng-controller="SidebarNotebooksController" ng-show="isVisible()">
-			<ul class="nav nav-sidebar sidebar-no-border" ng-hide="sidebarCollapsed">
-			        <div class="fa sidebar-collapse-switch" ng-show="!expandedNoteLayout"
+        <div class="fa sidebar-collapse-switch" ng-show="!expandedNoteLayout"
                          ng-class="sidebarCollapsed ? 'fa-chevron-right sidebar-collapse-switch-closed' : 'fa-chevron-left col-sm-offset-3 col-md-offset-2'"
                          ng-click="sidebarCollapsed = !sidebarCollapsed" ng-init="sidebarCollapsed = false"></div>
+		<div id="sidebarNotebooks" class="col-sm-3 col-md-2 sidebar hidden-xs animate-panel disable-selection" ng-controller="SidebarNotebooksController" ng-show="isVisible()">
+			<ul class="nav nav-sidebar sidebar-no-border" ng-hide="sidebarCollapsed">
 				<div class="tree">
 					<ul class="tree-base">
 						<li>
@@ -67,8 +67,8 @@
 		</div>
 
 		<div id="sidebarNotes" class="col-sm-4 col-md-3 sidebar hidden-xs animate-panel"
-             ng-controller="SidebarNotesController" ng-show="isVisible()" ng-class="sidebarCollapsed ? '' : 'col-sm-offset-3 col-md-offset-2'">
-			<ul id="notes-list" class="nav nav-sidebar notes-list sidebar-no-border" ng-controller="NotesListController">
+             ng-controller="SidebarNotesController" ng-show="isVisible()" ng-class="sidebarCollapsed ? 'sidebar-collapsed-notes' : 'col-sm-offset-3 col-md-offset-2'">
+			<ul id="notes-list" class="nav nav-sidebar notes-list sidebar-no-border" ng-controller="NotesListController" ng-class="sidebarCollapsed ? 'sidebar-collapsed-notes-list' : ''">
 				<li class="notes-list-item" ng-cloak ng-repeat="note in notes"
 					ng-click="noteSelect(note.notebook_id, note.id)"
 					ng-dblclick="editNote(note.notebook_id, note.id)"


### PR DESCRIPTION
Fix issues caused by previous PR https://github.com/twostairs/paperwork/pull/499 - the switch is now clickable properly and a gap is left when the sidebar is collapsed to display the switch in a clearer way as shown 
![2015-09-02 22_09_31-paperwork](https://cloud.githubusercontent.com/assets/6073063/9681927/6a69dd8a-5334-11e5-80f5-086e05a75c41.png)
