### PR TITLE
Change Paperwork logo link to avoid bug

### DIFF
--- a/frontend/app/views/layouts/user-layout.blade.php
+++ b/frontend/app/views/layouts/user-layout.blade.php
@@ -31,7 +31,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="paperwork-logo navbar-brand transition-effect" href="[[ URL::route("/") ]]"
+            <a class="paperwork-logo navbar-brand transition-effect" href="/#/"
                     ><img src="[[ asset('images/navbar-logo.png') ]]"> Paperwork</a>
         </div>
         <div class="navbar-collapse collapse">


### PR DESCRIPTION
There seems to a bug when the URL is /# which stops the view from continuing to load. 