### PR TITLE
Add white background to notes in notes-list

### DIFF
--- a/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
+++ b/frontend/app/less/paperwork-themes/paperwork-v1/paperwork-v1-custom.less
@@ -465,6 +465,7 @@ ul.nav-tabs-margin {
   .notes-list-item {
       margin-right: 1px;
       border-bottom: 1px solid @gray-light;
+      background-color: @white;
       a {
         border: 2px solid @white;
       }


### PR DESCRIPTION
It prevents a transparent background appearing for the note being dragged without clicking it first (to make it "active").