### PR TITLE
Added private field to package.json

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,5 +17,6 @@
     "watch": "gulp watch",
     "bower": "gulp bower",
     "bower-update": "gulp bower-update"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
This should remove the No README data warning during npm install. Also, it should remove the other warnings. 