### PR TITLE
Removed timestamps from languages table

### DIFF
--- a/frontend/app/database/migrations/2014_07_22_194050_initialize.php
+++ b/frontend/app/database/migrations/2014_07_22_194050_initialize.php
@@ -38,7 +38,6 @@ class Initialize extends Migration
         Schema::create('languages', function (Blueprint $table) {
             $table->char('id', 36)->default(null)->primary();
             $table->char('language_code', 7);
-            $table->timestamps();
             $table->softDeletes();
             $table->engine = 'InnoDB';
         });


### PR DESCRIPTION
@mrusme You can merge this pull request if you think that the timestamp fields can be removed from the languages table. I have updated the initial migration file. I understand that this could not be the best way but I think this is the only way since the languages table is being populated in this file. From all the options available, I've edited the file to make the minimum changes. 