### PR TITLE
Added Deploy to Heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Paperwork - OpenSource note-taking & archiving
 [![Join the chat at https://gitter.im/twostairs/paperwork](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/twostairs/paperwork?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/twostairs/paperwork.svg?branch=master)](https://travis-ci.org/twostairs/paperwork)
 
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/twostairs/paperwork/tree/deploy-heroku-develop)
+
 <img src="https://raw.githubusercontent.com/twostairs/paperwork/master/paperwork-logo.png" width="250" align="left" />
 
 Paperwork aims to be an open-source, self-hosted alternative to services like Evernote ®, Microsoft OneNote ® or Google Keep ®.
@@ -24,12 +26,12 @@ Ready to install? See the [Wiki](https://github.com/twostairs/paperwork/wiki) fo
 
 **Sandstorm**
 
-Demo: [Paperwork on Sandstorm](https://oasis.sandstorm.io/appdemo/vxe8awcxvtj6yu0vgjpm1tsaeu7x8v8tfp71tyvnm6ykkephu9q0)  
-Website: [sandstorm.io](https://sandstorm.io)  
-Github: [https://github.com/sandstorm-io/sandstorm](https://github.com/sandstorm-io/sandstorm)  
+Demo: [Paperwork on Sandstorm](https://oasis.sandstorm.io/appdemo/vxe8awcxvtj6yu0vgjpm1tsaeu7x8v8tfp71tyvnm6ykkephu9q0)
+Website: [sandstorm.io](https://sandstorm.io)
+Github: [https://github.com/sandstorm-io/sandstorm](https://github.com/sandstorm-io/sandstorm)
 
 **Cloudron**
 
-Demo: [Paperwork on Cloudron](https://my-demo.cloudron.me) (username: cloudron password: cloudron)  
-Website: [cloudron.io](https://cloudron.io)  
-Github: [https://github.com/cloudron-io/paperwork-app](https://github.com/cloudron-io/paperwork-app)  
+Demo: [Paperwork on Cloudron](https://my-demo.cloudron.me) (username: cloudron password: cloudron)
+Website: [cloudron.io](https://cloudron.io)
+Github: [https://github.com/cloudron-io/paperwork-app](https://github.com/cloudron-io/paperwork-app)


### PR DESCRIPTION
This adds a Deploy to Heroku button. The deployment is done based on the 'deploy-heroku-develop' branch that is a modified copy of the develop branch. The main differences are the moving of composer.json to the root folder, the addition of composer.lock and all CSS and Javascript files are included already. 

This should help in #97. 