### PR TITLE
Added Deploy to Heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Paperwork - OpenSource note-taking & archiving
 [![Join the chat at https://gitter.im/twostairs/paperwork](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/twostairs/paperwork?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/twostairs/paperwork.svg?branch=master)](https://travis-ci.org/twostairs/paperwork)
 
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/twostairs/paperwork/tree/deploy-heroku-develop)
+
 <img src="https://raw.githubusercontent.com/twostairs/paperwork/master/paperwork-logo.png" width="250" align="left" />
 
 Paperwork aims to be an open-source, self-hosted alternative to services like Evernote ®, Microsoft OneNote ® or Google Keep ®.
@@ -14,9 +16,9 @@ For the back-end part a MySQL database stores everything. With such common requi
 
 ## Demo (not yet)
 
-At [demo.paperwork.rocks](http://demo.paperwork.rocks) a demonstration of Paperwork was available. However, this has been disabled due to a lack of sponsorship. We understand this is not ideal but, hopefully, the matter will be resolved soon in order to be able to offer the demo again. 
+At [demo.paperwork.rocks](http://demo.paperwork.rocks) a demonstration of Paperwork was available. However, this has been disabled due to a lack of sponsorship. We understand this is not ideal but, hopefully, the matter will be resolved soon in order to be able to offer the demo again.
 
-If you really want to experience what Paperwork is, you can try a demo running a port of Paperwork built for Sandstorm.io. Please note that Sandstorm.io is by no means related to or endorsed by Paperwork and that this demo is not under the control of any of Paperwork's active contributors. This demo can be accessed from [this link](https://oasis.sandstorm.io/appdemo/vxe8awcxvtj6yu0vgjpm1tsaeu7x8v8tfp71tyvnm6ykkephu9q0). **Note**: This demo does not run the latest version of Paperwork and some features may be disabled. Thank you to the Sandtorm.io community for providing this demo to us. 
+If you really want to experience what Paperwork is, you can try a demo running a port of Paperwork built for Sandstorm.io. Please note that Sandstorm.io is by no means related to or endorsed by Paperwork and that this demo is not under the control of any of Paperwork's active contributors. This demo can be accessed from [this link](https://oasis.sandstorm.io/appdemo/vxe8awcxvtj6yu0vgjpm1tsaeu7x8v8tfp71tyvnm6ykkephu9q0). **Note**: This demo does not run the latest version of Paperwork and some features may be disabled. Thank you to the Sandtorm.io community for providing this demo to us.
 
 ## Getting Started
 


### PR DESCRIPTION
This is the same as #650 but targeted to the develop branch. Actually, I noticed the Deploy to Heroku logo is similar to the Paperwork one. Nice. 