### PR TITLE
Check for when we have no selected users

### DIFF
--- a/frontend/app/controllers/AdminController.php
+++ b/frontend/app/controllers/AdminController.php
@@ -7,14 +7,16 @@ class AdminController extends BaseController {
 	
 	public function deleteOrRestoreUsers() {
 	    $input = Input::get('selected_users');
-	    foreach($input as $single_input) {
-	        $user = User::withTrashed()->where('id', '=', $single_input);
-	        if(Input::get('restore')) {
-	            $user->restore();
-	        }else{
-	            $user->delete();
-	        }
-	    }
+        if (!empty($input)) {
+            foreach ($input as $single_input) {
+                $user = User::withTrashed()->where('id', '=', $single_input);
+                if (Input::get('restore')) {
+                    $user->restore();
+                } else {
+                    $user->delete();
+                }
+            }
+        }
 	    return Redirect::route("admin/console");
 	}
 }


### PR DESCRIPTION
Fix Whoops in Admin when we click "Delete" or "Restore" when we've not selected a user.