### PR TITLE
Allow port Specification on PostgreSQL

### DIFF
--- a/frontend/public/setup.php
+++ b/frontend/public/setup.php
@@ -638,12 +638,12 @@
                 if($(this)[0].id !== "") {
                     var chosenText = $(this)[0].id;
                     $("#dbms_choice").val(chosenText);
-                    if(chosenText === "pgsql" || chosenText === "sqlsrv") {
+                    if(chosenText === "sqlsrv") {
                         $("#portFieldElement").hide();
                         $("#serverFieldElement, #usernameFieldElement, #passwordFieldElement").show();
                     }else if(chosenText === "sqlite") {
                         $("#serverFieldElement, #portFieldElement, #usernameFieldElement, #passwordFieldElement").hide();
-                    }else if(chosenText === "mysql") {
+                    }else if(chosenText === "pgsql" || chosenText === "mysql") {
                         $("#serverFieldElement, #portFieldElement, #usernameFieldElement, #passwordFieldElement").show();
                     }
                 }


### PR DESCRIPTION
When trying to deploy to heroku, I needed to specify a port. This allows me to specify it.

No other changes are required, as the backend handles this correctly.

Supercedes: #661 