### PR TITLE
Add new configuration option 'trustProxy' to enable reverse proxy use

### DIFF
--- a/frontend/app/config/paperwork.php
+++ b/frontend/app/config/paperwork.php
@@ -25,6 +25,10 @@ return array(
 	| your Paperwork installation is reachable from your LAN using the
 	| previously defined 'external' settings, you can skip the 'internal'
 	| configuration.
+        |
+        | trustProxy should be false if no extra reverse proxy/load balancer is
+        | used, or can be set to array of proxy ip address' to lock it down,
+        | or true to allow all.
 	|
 	*/
 	'access' => array(
@@ -33,7 +37,9 @@ return array(
 			'ports' => array(
 				'http'		 => 80,
 				'https' 	 => 443,
-				'forceHttps' => true
+				'forceHttps' => true,
+                                'trustProxy' => true
+
 			)
 		),
 	//  if same as external:
@@ -43,7 +49,9 @@ return array(
 			'ports' => array(
 				'http'		 => 8888,
 				'https' 	 => 8443,
-				'forceHttps' => false
+				'forceHttps' => false,
+                                'trustProxy' => false
+
 			)
 		)
 	),

--- a/frontend/app/config/paperwork.php
+++ b/frontend/app/config/paperwork.php
@@ -38,7 +38,7 @@ return array(
 				'http'		 => 80,
 				'https' 	 => 443,
 				'forceHttps' => true,
-                                'trustProxy' => true
+				'trustProxy' => true
 
 			)
 		),
@@ -50,7 +50,7 @@ return array(
 				'http'		 => 8888,
 				'https' 	 => 8443,
 				'forceHttps' => false,
-                                'trustProxy' => false
+				'trustProxy' => false
 
 			)
 		)

--- a/frontend/app/filters.php
+++ b/frontend/app/filters.php
@@ -29,13 +29,13 @@ App::before(function($request)
 		is_array($access[$zone]) &&
 		array_key_exists('dns', $access[$zone]) &&
 		$access[$zone]['dns'] == $requestServerName) {
-                        if($access[$zone]['ports']['trustProxy'] === true) {
-                                $proxyip = $access[$zone]['ports']['trustProxy'];
-                                if($proxyip === true) {
-                                        $proxyip = [ $request->getClientIp() ];
-                                }
-                                Request::setTrustedProxies( $proxyip );
-                        }
+			if($access[$zone]['ports']['trustProxy'] === true) {
+				$proxyip = $access[$zone]['ports']['trustProxy'];
+				if($proxyip === true) {
+					$proxyip = [ $request->getClientIp() ];
+				}
+				Request::setTrustedProxies( $proxyip );
+			}
 
 			if(array_key_exists('ports', $access[$zone]) &&
 			is_array($access[$zone]['ports']) &&

--- a/frontend/app/filters.php
+++ b/frontend/app/filters.php
@@ -14,7 +14,7 @@
 App::before(function($request)
 {
 	$access = Config::get('paperwork.access');
-	$requestServerName = Request::server ("SERVER_NAME");
+	$requestServerName = Request::server ("HTTP_HOST");
 	$zones = array('external', 'internal');
 
     App::singleton('paperworkSession', function(){
@@ -29,6 +29,14 @@ App::before(function($request)
 		is_array($access[$zone]) &&
 		array_key_exists('dns', $access[$zone]) &&
 		$access[$zone]['dns'] == $requestServerName) {
+                        if($access[$zone]['ports']['trustProxy'] === true) {
+                                $proxyip = $access[$zone]['ports']['trustProxy'];
+                                if($proxyip === true) {
+                                        $proxyip = [ $request->getClientIp() ];
+                                }
+                                Request::setTrustedProxies( $proxyip );
+                        }
+
 			if(array_key_exists('ports', $access[$zone]) &&
 			is_array($access[$zone]['ports']) &&
 			array_key_exists('forceHttps', $access[$zone]['ports'])) {


### PR DESCRIPTION
I had the same sort of issue as #197 when trying to use paperwork behind a reverse proxy.
In my case I deployed an instance of the zuhkov/paperwork docker to quickly trial paperwork.
I have my normal server nginx handle ssl and proxy_pass through to the docker.

This gave me problems with the paperwork app thinking it's http and returning http links rather than https.
It also was not detecting the right host name due to the nginx in the container not seeing the external dns host name as server_name so could not match up the right access settings array.

These problems are solved for me by matching against client reported host name (HTTP_HOST) rather than server reported (SERVER_NAME), and adding extra settings to enable the laveral setTrustedProxies() function appropriately as per:
http://laravel-tricks.com/tricks/fix-ssl-in-laravel-4-when-server-is-behind-a-load-balancer-or-a-reverse-proxy
or 
http://laravel-tricks.com/tricks/fix-ssl-in-laravel-4-when-using-cloudflare

This change supports both usages.