### PR TITLE
Run PostgreSQL-specific migrations only for PostgreSQL installs

### DIFF
--- a/frontend/app/database/migrations/2016_10_03_203511_fix_timestamps_for_postgres.php
+++ b/frontend/app/database/migrations/2016_10_03_203511_fix_timestamps_for_postgres.php
@@ -12,44 +12,46 @@ class FixTimestampsForPostgres extends Migration {
 	 */
 	public function up()
 	{
-		DB::statement('ALTER TABLE attachment_version ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE attachment_version ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE attachments ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE attachments ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE language_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE language_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE note_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE note_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE notebook_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE notebook_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE notebooks ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE notebooks ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE notes ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE notes ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE settings ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE settings ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE shortcuts ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE shortcuts ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE tag_note ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE tag_note ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE tags ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE tags ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE users ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE versions ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE versions ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+		if(DB::getDriverName() === "pgsql") {
+			DB::statement('ALTER TABLE attachment_version ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE attachment_version ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE attachments ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE attachments ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE language_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE language_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE note_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE note_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE notebook_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE notebook_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE notebooks ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE notebooks ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE notes ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE notes ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE settings ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE settings ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE shortcuts ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE shortcuts ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE tag_note ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE tag_note ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE tags ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE tags ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE users ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE versions ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE versions ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+		}
 	}
 
 	/**
@@ -59,43 +61,45 @@ class FixTimestampsForPostgres extends Migration {
 	 */
 	public function down()
 	{
-		DB::statement('ALTER TABLE attachment_version ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE attachment_version ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE attachments ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE attachments ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE language_user ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE language_user ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE note_user ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE note_user ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE notebook_user ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE notebook_user ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE notebooks ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE notebooks ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE notes ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE notes ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE settings ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE settings ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE shortcuts ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE shortcuts ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE tag_note ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE tag_note ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE tags ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE tags ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE users ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE users ALTER COLUMN updated_at DROP DEFAULT;');
-
-		DB::statement('ALTER TABLE versions ALTER COLUMN created_at DROP DEFAULT;');
-		DB::statement('ALTER TABLE versions ALTER COLUMN updated_at DROP DEFAULT;');
+		if(DB::getDriverName() === "pgsql") {
+			DB::statement('ALTER TABLE attachment_version ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE attachment_version ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE attachments ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE attachments ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE language_user ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE language_user ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE note_user ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE note_user ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE notebook_user ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE notebook_user ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE notebooks ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE notebooks ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE notes ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE notes ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE settings ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE settings ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE shortcuts ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE shortcuts ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE tag_note ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE tag_note ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE tags ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE tags ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE users ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE users ALTER COLUMN updated_at DROP DEFAULT;');
+	
+			DB::statement('ALTER TABLE versions ALTER COLUMN created_at DROP DEFAULT;');
+			DB::statement('ALTER TABLE versions ALTER COLUMN updated_at DROP DEFAULT;');
+		}
 	}
 }

--- a/frontend/app/database/migrations/2016_10_21_224100_fix_timestamps_for_postgres_again.php
+++ b/frontend/app/database/migrations/2016_10_21_224100_fix_timestamps_for_postgres_again.php
@@ -12,44 +12,46 @@ class FixTimestampsForPostgresAgain extends Migration {
 	 */
 	public function up()
 	{
-		DB::statement('ALTER TABLE attachment_version ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE attachment_version ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE attachments ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE attachments ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE language_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE language_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE note_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE note_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE notebook_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE notebook_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE notebooks ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE notebooks ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE notes ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE notes ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE settings ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE settings ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE shortcuts ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE shortcuts ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE tag_note ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE tag_note ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE tags ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE tags ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE users ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-
-		DB::statement('ALTER TABLE versions ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
-		DB::statement('ALTER TABLE versions ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+		if(DB::getDriverName() === "pgsql") {
+			DB::statement('ALTER TABLE attachment_version ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE attachment_version ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE attachments ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE attachments ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE language_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE language_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE note_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE note_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE notebook_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE notebook_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE notebooks ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE notebooks ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE notes ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE notes ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE settings ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE settings ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE shortcuts ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE shortcuts ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE tag_note ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE tag_note ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE tags ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE tags ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE users ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+	
+			DB::statement('ALTER TABLE versions ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+			DB::statement('ALTER TABLE versions ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP(0);');
+		}
 	}
 
 	/**
@@ -59,43 +61,45 @@ class FixTimestampsForPostgresAgain extends Migration {
 	 */
 	public function down()
 	{
-		DB::statement('ALTER TABLE attachment_version ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE attachment_version ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE attachments ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE attachments ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE language_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE language_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE note_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE note_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE notebook_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE notebook_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE notebooks ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE notebooks ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE notes ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE notes ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE settings ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE settings ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE shortcuts ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE shortcuts ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE tag_note ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE tag_note ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE tags ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE tags ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE users ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
-
-		DB::statement('ALTER TABLE versions ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
-		DB::statement('ALTER TABLE versions ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+		if(DB::getDriverName() === "pgsql") {
+			DB::statement('ALTER TABLE attachment_version ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE attachment_version ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE attachments ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE attachments ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE language_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE language_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE note_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE note_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE notebook_user ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE notebook_user ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE notebooks ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE notebooks ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE notes ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE notes ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE settings ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE settings ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE shortcuts ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE shortcuts ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE tag_note ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE tag_note ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE tags ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE tags ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE users ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+	
+			DB::statement('ALTER TABLE versions ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;');
+			DB::statement('ALTER TABLE versions ALTER COLUMN updated_at SET DEFAULT CURRENT_TIMESTAMP;');
+		}
 	}
 }


### PR DESCRIPTION
This should allow users to install Paperwork again. I'm self-merging this since it is changing a breaking problem for users. 