### PR TITLE
Implemented Checkboxes Extra Feature

### DIFF
--- a/frontend/app/config/paperwork.php
+++ b/frontend/app/config/paperwork.php
@@ -208,4 +208,14 @@ return array(
 	'removeEditorButtonsCKEditor' =>
 		isset($configuration->removeEditorButtonsCKEditor) ? $configuration->removeEditorButtonsCKEditor : 'Cut,Copy,Paste,Undo,Redo,Anchor,Underline,Strike,Subscript,Superscript',
 
+	/*
+	|-------------------------------------------------------------------------
+	| EXTRA Features
+	|-------------------------------------------------------------------------
+	| These are candidates to be plugins when the necessary functionality is
+	| implemented. Until then, these are implemented in core but can be
+	| turned off from the configuration settings.
+	*/
+	'extra_feature_checkboxes' => isset($configuration->extra_feature_checkboxes) ? ($configuration->extra_feature_checkboxes) : true,
+
 );

--- a/frontend/app/js/paperwork/notes/notes_edit.controller.js
+++ b/frontend/app/js/paperwork/notes/notes_edit.controller.js
@@ -20,6 +20,7 @@ angular.module('paperworkNotes').controller('NotesEditController',
             $rootScope.versionSelectedId = {'notebookId': notebookId, 'noteId': noteId, 'versionId': 0};
             NotesService.getNoteById(noteId);
             $rootScope.templateNoteEdit = $rootScope.getNoteByIdLocal(noteId);
+
             if (typeof $rootScope.templateNoteEdit == "undefined" || $rootScope.templateNoteEdit == null) {
                 $rootScope.templateNoteEdit = {};
             }
@@ -29,6 +30,18 @@ angular.module('paperworkNotes').controller('NotesEditController',
                 $rootScope.templateNoteEdit.version.title = $rootScope.templateNoteEdit.title;
                 $rootScope.templateNoteEdit.version.content = $rootScope.templateNoteEdit.content;
             }
+
+            $scope.$watch('templateNoteEdit.version.content', function(value) {
+                var nonEditableMessage = $rootScope.i18n.messages.non_editable_checkbox_explanation;
+                var rawContent = $rootScope.templateNoteEdit.version.content;
+                var checkedBox = "<input type=\"checkbox\" checked disabled title=\"" + nonEditableMessage + "\">";
+                var uncheckedBox = "<input type=\"checkbox\" disabled title=\"" + nonEditableMessage + "\">";
+                if (rawContent.indexOf(checkedBox) !== -1 || rawContent.indexOf(uncheckedBox) !== -1) {
+                    rawContent = rawContent.replace(checkedBox, "[X]");
+                    rawContent = rawContent.replace(uncheckedBox, "[]");
+                    $rootScope.templateNoteEdit.version.content = rawContent;
+                }
+            });
 
             NotesService.getNoteVersionAttachments($rootScope.getNotebookSelectedId(), ($rootScope.getNoteSelectedId(true)).noteId, $rootScope.getVersionSelectedId(true).versionId,
                 function (response) {

--- a/frontend/app/lang/en/messages.php
+++ b/frontend/app/lang/en/messages.php
@@ -95,5 +95,6 @@ return array(
             'assets_not_found_description' => 'We have not found all the files required to run Paperwork. Did you run composer install, npm install, bower install and gulp?'
         )
 	),
-	'required_configuration_setting_register_admin_tooltip' => 'You need to set your registration configuration setting to \'admin\''
+	'required_configuration_setting_register_admin_tooltip' => 'You need to set your registration configuration setting to \'admin\'',
+	'non_editable_checkbox_explanation' => 'To check or uncheck this checkbox, edit the note and put X (to check) or leave empty (to uncheck) the space between the [ ] before this line'
 );

--- a/frontend/app/models/Version.php
+++ b/frontend/app/models/Version.php
@@ -21,8 +21,24 @@ class Version extends PaperworkModel {
 	public function attachments() {
 		return $this->belongsToMany('Attachment')->withTimestamps();
 	}
-	public function user(){
-	  return $this->belongsTo('User');
+
+	public function user() {
+		return $this->belongsTo('User');
+	}
+	
+	/**
+	 * This could be implemented as an extension. Since Paperwork at the
+	 * moment does not support extensions, I am adding as a core feature. 
+	 */
+	public function getContentAttribute($rawValue) {
+		if(Config::get('paperwork.extra_feature_checkboxes')) {
+			$nonEditableMessage = Lang::get('messages.non_editable_checkbox_explanation');
+			$newValue = preg_replace('/<(p|br)>\[( |)\](.*?)<(\/p|br)>/', '<$1><input type="checkbox" disabled title="' . $nonEditableMessage . '"> $3 <$4>', $rawValue);
+			$newValue = preg_replace('/<(p|br)>\[(X|x)\](.*?)<(\/p|br)>/', '<$1><input type="checkbox" checked disabled title="' . $nonEditableMessage . '"> $3 <$4>', $newValue);
+			return $newValue;
+		}else{
+			return $rawValue;
+		}
 	}
 }
 

--- a/frontend/app/storage/config/default_paperwork.json
+++ b/frontend/app/storage/config/default_paperwork.json
@@ -3,5 +3,6 @@
     "forgot_password": true,
     "showIssueReportingLink": false,
     "maximumAttachmentsPerNote": 10,
-    "removeEditorButtonsCKEditor": "Cut,Copy,Paste,Undo,Redo,Anchor,Underline,Strike,Subscript,Superscript"
+    "removeEditorButtonsCKEditor": "Cut,Copy,Paste,Undo,Redo,Anchor,Underline,Strike,Subscript,Superscript",
+    "extra_feature_checkboxes": true
 }


### PR DESCRIPTION
This feature, when activated through the paperwork configuration
setting, allows a quick way to create disabled checkboxes in the
note view by starting a line with [] or [X] depending on the state.
These checkboxes are not clickable and in the edit view are
transformed again in [] or [X]. A tooltip explaining the feature
is added to the checkboxes.

This could be a plugin but since there's no implementation for them,
this could be implemented in core.