### PR TITLE
Make the compose command follow the image default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ ADD frontend/ /app
 
 # Grant execution permission on composer
 RUN chmod +x /usr/local/bin/composer && \
-
     # Install packages
     apk add --no-cache \
     bash \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,3 @@ web:
     - "8080:80"
   links:
     - db
-  command: /app/docker-runner.sh


### PR DESCRIPTION
`docker-compose.yml` will default to using the command in the image if
one is not supplied. An issue (867) arose when the location of the command to
run was changed, but only in `Dockerfile`. A clean solution would be to
let the docker-compose use the image default, rather than change it both
places every time. (If this is not the preferred method, either way, the
docker-compose command should be updated)

Also, a white space was removed from the `Dockerfile` as docker build
was throwing warnings about empty lines following `\\` and stating it
would become an error soon:

```
[WARNING]: Empty continuation lines will become errors in a future
release.
```